### PR TITLE
Revert "chore(deps): update container image caddy to v2.8.1"

### DIFF
--- a/cluster/apps/household/vikunja/helm-release.yaml
+++ b/cluster/apps/household/vikunja/helm-release.yaml
@@ -38,7 +38,7 @@ spec:
           main:
             image:
               repository: caddy
-              tag: 2.8.1-alpine
+              tag: 2.8.0-alpine
               pullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
Reverts mrwulf/home-cluster#1510

no linux/amd64 image for caddy:2.8.1-alpine