### PR TITLE
fix(ai): override securityContext for pullmd's mcp container

### DIFF
--- a/.claude/skills/AddClusterApp/SKILL.md
+++ b/.claude/skills/AddClusterApp/SKILL.md
@@ -37,6 +37,8 @@ Before writing any YAML, resolve each of these against CLAUDE.md's "Pattern refe
 - **Traefik resolves `ExtensionRef` middleware in the route's own namespace**, not `networking` where middlewares are defined. If a new namespace needs `rfc1918-ips` or `traefik-middleware-chain-pocket-id`, add it to the Kyverno `sync-middlewares.yaml` clone policy first or the `HTTPRoute` will fail to resolve the filter.
 - **CPU limits get silently stripped by a Kyverno policy** (`remove-cpu-limit.yaml`) even if you set one — but don't rely on that; just don't set one (rule 6).
 - **Docs drift**: verify any version number or instance name CLAUDE.md states (e.g. a Postgres major version) against the actual live manifest before trusting it as fact — this skill was created after finding one such drift.
+- **ToolHive's operator applies a fixed non-root `securityContext` to every `MCPServer`'s `mcp` container by default.** If the upstream image's own entrypoint expects to start as root and drop privileges itself (common in images using `su-exec`/`gosu`), that default will crash it (`setgroups: Operation not permitted` or similar). Override `podTemplateSpec.spec.containers[name=mcp].securityContext` to match what the image actually needs — check its entrypoint script, don't guess.
+- **That `podTemplateSpec` container override replaces the whole container spec for the matched name, not just the fields you set.** If you override `securityContext` or `volumeMounts` on the `mcp` container, repeat `resources` there too — verified empirically that omitting it silently produces `resources: {}` even though the top-level `spec.resources` was set.
 
 ## Examples
 

--- a/cluster/apps/ai/toolhive/servers/mcp-pullmd.yaml
+++ b/cluster/apps/ai/toolhive/servers/mcp-pullmd.yaml
@@ -36,6 +36,35 @@ spec:
     spec:
       containers:
         - name: mcp
+          # pullmd's entrypoint runs as root, chowns /data, then drops to its
+          # own unprivileged "app" user via su-exec. The operator's default
+          # securityContext runs the container directly as a fixed non-root
+          # UID/GID that doesn't match pullmd's own user, so su-exec's
+          # setuid/setgid fails outright (verified: CrashLoopBackOff,
+          # "su-exec: setgroups(101): Operation not permitted"). Overriding
+          # here restores the image's own root-then-drop model instead of
+          # fighting it, while keeping capabilities minimal (rule 9).
+          # NOTE: this podTemplateSpec container entry replaces the whole
+          # container spec rather than field-merging onto it - `resources`
+          # must be repeated here too, or the operator silently drops it
+          # (verified empirically: omitting it produced `resources: {}`).
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+              add: ["SETUID", "SETGID", "CHOWN"]
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
## Why
After merging #5019, `mcp-pullmd-0` crash-looped in production:
```
su-exec: setgroups(101): Operation not permitted
```
pullmd's entrypoint runs as root, chowns `/data`, then drops privileges to its own "app" user via `su-exec`. ToolHive's operator applies a fixed non-root `securityContext` (UID/GID 1000) to every `MCPServer`'s `mcp` container by default, which doesn't match pullmd's own user — so `su-exec`'s `setuid`/`setgid` fails outright before the process ever starts.

## Fix
Overrides `podTemplateSpec.spec.containers[name=mcp].securityContext` on `mcp-pullmd` so the container starts as root (letting pullmd's own root-then-drop entrypoint work as designed), while keeping the capability set minimal (`drop: ALL` + only `SETUID`/`SETGID`/`CHOWN` added back) and `readOnlyRootFilesystem: true`.

Also restates `resources` inside that same `podTemplateSpec` container override — verified empirically that the operator's container-name-matched patch replaces the whole container entry, so omitting `resources` there silently dropped the top-level `spec.resources` (confirmed live: `resources: {}` on the pod after the first live patch, before I added it back here).

## Verification
- Live-tested this exact `securityContext` on the running cluster via a direct patch first (root-caused the crash, confirmed the fix resolves it — `mcp-pullmd-0` went `1/1 Running`, 0 restarts) before committing it to git as the source of truth.
- `mise x -- task test:all` passes.
- `kubectl kustomize cluster/apps/ai/toolhive/servers | kubectl apply --dry-run=server -f -` validates cleanly.
- Added both findings (the securityContext mismatch, and the podTemplateSpec container-replace behavior) to the `AddClusterApp` skill's Gotchas.