### PR TITLE
fix(openclaw): auto-migrate state on startup for v2026.8.1

### DIFF
--- a/cluster/apps/ai/openclaw/app/helm-release.yaml
+++ b/cluster/apps/ai/openclaw/app/helm-release.yaml
@@ -22,6 +22,58 @@ spec:
       openclaw:
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          migrate:
+            image:
+              repository: ghcr.io/openclaw/openclaw
+              tag: 2026.8.1
+            command:
+              - sh
+              - -c
+              - |
+                set -eu
+                node dist/index.js doctor --fix --allow-exec || true
+                node dist/index.js doctor --session-sqlite import --session-sqlite-all-agents || true
+                if [ -e /home/node/.openclaw/sessions ]; then
+                  mkdir -p /home/node/.openclaw/legacy-session-store-archive
+                  mv /home/node/.openclaw/sessions "/home/node/.openclaw/legacy-session-store-archive/sessions-$(date +%s)"
+                fi
+                mkdir -p /home/node/.openclaw/legacy-auth-backup
+                for f in /home/node/.openclaw/agents/*/agent/auth.json /home/node/.openclaw/agents/*/agent/auth-profiles.json; do
+                  [ -e "$f" ] || continue
+                  agent=$(basename "$(dirname "$(dirname "$f")")")
+                  mv "$f" "/home/node/.openclaw/legacy-auth-backup/${agent}.$(basename "$f")"
+                done
+                chown -R 1000:1000 /home/node/.openclaw
+                if [ -d /home/node/.openclaw/extensions ]; then
+                  chown -R root:1000 /home/node/.openclaw/extensions
+                  chmod -R g+rX /home/node/.openclaw/extensions
+                fi
+            env:
+              HOME: /home/node
+              PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/node/.openclaw/bin/bin"
+              npm_config_prefix: home/node/.openclaw/npm
+            envFrom:
+              - secretRef:
+                  name: openclaw-secrets
+            securityContext:
+              # Runs as root: doctor/session-sqlite migration steps need to chmod/chown
+              # files across ownership boundaries, and this cluster's container runtime
+              # doesn't propagate added Linux capabilities to non-root processes (verified
+              # empirically — capabilities.add lands in the bounding set only, never
+              # effective/ambient, for a non-zero runAsUser). Scoped to this one-shot init
+              # step; the app container keeps its non-root, all-capabilities-dropped profile.
+              runAsUser: 0
+              runAsGroup: 0
+              runAsNonRoot: false
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
         containers:
           app:
             image:


### PR DESCRIPTION
## Problem

`openclaw` was crash-looping in prod after the v2026.8.1 bump (merged via #5006): the new release requires several state/config migrations that never run automatically, so the gateway either refuses to start or self-terminates seconds after appearing to boot. Flux kept Helm-upgrading, timing out, and auto-rolling-back on every reconcile, which was also generating a chunk of the etcd-timeout/GitHub-ratelimit noise seen in cluster events during this window.

Verified live (openclaw scaled to 0, a throwaway root debug pod mounted on the same PVC) that this is not one issue but four, stacked:

1. **Config schema migration** — `openclaw.json` has several renamed/retired keys (`agents.list` → `agents.entries`, `memorySearch` → `memory.search`, binding `kind: "dm"` → `"direct"`, a retired model ref, etc.). `doctor --fix` handles this correctly and idempotently — diffed the before/after, it's a clean forward migration, no data loss.
2. **Legacy session-store migration** (JSON → SQLite) — `doctor --session-sqlite import` migrates the data fine, but its own "archive the old files" cleanup step has a real bug: the archive path is always computed as a *sibling* of the state directory, which lands outside the PVC whenever `.openclaw` is mounted as its own volume (a completely standard container/K8s pattern, not specific to this cluster). Worked around by relocating the legacy store within the PVC ourselves after import.
3. **Plugin ownership trust check** — the `whatsapp` extension was installed at runtime by the app's own non-root user, which was fine before 2026.8.x added an ownership-based plugin trust gate (`expected uid=0 or root`). `openclaw update repair` (the tool's own suggested fix) silently no-ops on it. Fixed by chowning `extensions/` to `root:node` with group-read — root satisfies the trust check, group access keeps it readable by the non-root app process.
4. **Auth-profile credential migration** — `core/doctor/auth-profiles` (even `--fix --force`) throws instead of migrating for 3 agents' legacy `auth-profiles.json`/`auth.json` files. No working automated fix found. Moved those files aside (not deleted — archived under `legacy-auth-backup/` on the same PVC) and accepted that those agents' cached provider logins need re-authenticating post-deploy.

## Fix

Added a root-run `initContainer` that performs all four steps against the shared PVC before the app container starts, so this self-heals via GitOps on every future migration too, instead of requiring another one-off manual intervention. Verified idempotent (reran against already-migrated state — clean no-op) and verified end-to-end against the real production pod: it now reaches `1/1 Ready` with the gateway at full `ready` state.

Root is required for this init step specifically because this cluster's container runtime doesn't propagate `capabilities.add` to a non-root process's effective/ambient set (confirmed empirically: `capabilities: {drop: [ALL], add: [FOWNER]}` under `runAsUser: 1000` left `CapEff`/`CapAmb` at zero). The main app container is untouched — still non-root, all capabilities dropped.

## Follow-up needed (not automatable)

WhatsApp itself needs a manual relink after this deploys — its session credentials lived in the auth files that got archived: `openclaw channels login --channel whatsapp`.

## Testing

- `mise x -- task test:lint:all` — clean (kubeconform: 0 invalid, 0 errors)
- `mise x -- task test:flux:validate` — `flux check` passes; the `flux build --dry-run` steps report their usual worktree-path warning, which is pre-existing/`ignore_error: true` per `Taskfile.yml`, not something this change introduced
- Live-verified against the real cluster (scaled `openclaw` to 0, ran the exact migration script from a throwaway root pod on the production PVC, confirmed idempotent, scaled back up — real pod is now healthy)