### PR TITLE
fix(openclaw): configure gateway.trustedProxies for pod CIDR

### DIFF
--- a/cluster/apps/ai/openclaw/app/helm-release.yaml
+++ b/cluster/apps/ai/openclaw/app/helm-release.yaml
@@ -121,3 +121,10 @@ spec:
         existingClaim: *app
         globalMounts:
           - path: /home/node/.openclaw
+      config:
+        type: configMap
+        name: openclaw-configmap
+        globalMounts:
+          - path: /home/node/.openclaw/openclaw.json
+            subPath: openclaw.json
+            readOnly: true

--- a/cluster/apps/ai/openclaw/app/kustomization.yaml
+++ b/cluster/apps/ai/openclaw/app/kustomization.yaml
@@ -5,3 +5,9 @@ kind: Kustomization
 resources:
   - ./secrets.sops.yaml
   - ./helm-release.yaml
+configMapGenerator:
+  - name: openclaw-configmap
+    files:
+      - ./resources/openclaw.json
+generatorOptions:
+  disableNameSuffixHash: true

--- a/cluster/apps/ai/openclaw/app/resources/openclaw.json
+++ b/cluster/apps/ai/openclaw/app/resources/openclaw.json
@@ -1,0 +1,5 @@
+{
+  "gateway": {
+    "trustedProxies": ["10.244.0.0/16"]
+  }
+}


### PR DESCRIPTION
openclaw v2026.8.1 added mandatory proxy client attribution on the gateway. Behind Traefik it was rejecting requests with:

```
proxy_attribution_required
```

Adds `gateway.trustedProxies: ["10.244.0.0/16"]` (the cluster pod CIDR, matching the existing pocket-id pattern) via a mounted ConfigMap at `/home/node/.openclaw/openclaw.json` (the default OpenClaw config path), keeping token auth unchanged.

Verified with `task test:lint:all` (kubeconform: 0 invalid) and by rendering the kustomization to confirm the ConfigMap and mount.
