### PR TITLE
fix(openclaw): escape ${agent} in migrate script from Flux postBuild substitution

### DIFF
--- a/cluster/apps/ai/openclaw/app/helm-release.yaml
+++ b/cluster/apps/ai/openclaw/app/helm-release.yaml
@@ -42,7 +42,7 @@ spec:
                 for f in /home/node/.openclaw/agents/*/agent/auth.json /home/node/.openclaw/agents/*/agent/auth-profiles.json; do
                   [ -e "$f" ] || continue
                   agent=$(basename "$(dirname "$(dirname "$f")")")
-                  mv "$f" "/home/node/.openclaw/legacy-auth-backup/${agent}.$(basename "$f")"
+                  mv "$f" "/home/node/.openclaw/legacy-auth-backup/$${agent}.$(basename "$f")"
                 done
                 chown -R 1000:1000 /home/node/.openclaw
                 if [ -d /home/node/.openclaw/extensions ]; then


### PR DESCRIPTION
A concurrent commit (`a87beb3d2`, merged in the same batch as #5029) added a `migrate` init-container whose shell script builds a filename using `${agent}` — a plain shell variable, not a Flux template var. Flux's `postBuild.substitute` on the `openclaw` Kustomization runs in strict mode and scans the whole rendered manifest for `${VAR}` tokens, so it tried to substitute `agent` and failed the build:

```
post build failed for 'HelmRelease.v2.helm.toolkit.fluxcd.io/openclaw': envsubst error: variable substitution failed: variable not set (strict mode): "agent"
```

This left the `openclaw` Kustomization stuck in `BuildFailed`/`ProgressingWithRetry` and the app down.

Fix: escape it as `$${agent}` so Flux's substitution reduces `$$` → literal `$`, restoring the original `${agent}` string for the container's own shell — no functional change to the migrate script. Verified by rendering the kustomization locally and confirming the only remaining `${...}` tokens are `$${agent}` (now escaped) and the pre-existing, correctly-substituted `${SECRET_DOMAIN}` hostname variable. `task test:lint:all` passes.
