### PR TITLE
fix(openclaw): merge trustedProxies into config instead of clobbering it

### DIFF
--- a/cluster/apps/ai/openclaw/app/helm-release.yaml
+++ b/cluster/apps/ai/openclaw/app/helm-release.yaml
@@ -44,6 +44,26 @@ spec:
                   agent=$(basename "$(dirname "$(dirname "$f")")")
                   mv "$f" "/home/node/.openclaw/legacy-auth-backup/$${agent}.$(basename "$f")"
                 done
+                node -e '
+                  const fs = require("fs");
+                  const path = "/home/node/.openclaw/openclaw.json";
+                  let cfg = {};
+                  if (fs.existsSync(path)) {
+                    try {
+                      cfg = JSON.parse(fs.readFileSync(path, "utf8"));
+                    } catch (e) {
+                      console.error("skip trustedProxies merge, could not parse existing config:", e.message);
+                      process.exit(0);
+                    }
+                  }
+                  cfg.gateway = cfg.gateway || {};
+                  const cidr = "10.244.0.0/16";
+                  const existing = Array.isArray(cfg.gateway.trustedProxies) ? cfg.gateway.trustedProxies : [];
+                  if (!existing.includes(cidr)) {
+                    cfg.gateway.trustedProxies = existing.concat([cidr]);
+                    fs.writeFileSync(path, JSON.stringify(cfg, null, 2));
+                  }
+                '
                 chown -R 1000:1000 /home/node/.openclaw
                 if [ -d /home/node/.openclaw/extensions ]; then
                   chown -R root:1000 /home/node/.openclaw/extensions
@@ -173,10 +193,3 @@ spec:
         existingClaim: *app
         globalMounts:
           - path: /home/node/.openclaw
-      config:
-        type: configMap
-        name: openclaw-configmap
-        globalMounts:
-          - path: /home/node/.openclaw/openclaw.json
-            subPath: openclaw.json
-            readOnly: true

--- a/cluster/apps/ai/openclaw/app/kustomization.yaml
+++ b/cluster/apps/ai/openclaw/app/kustomization.yaml
@@ -5,9 +5,3 @@ kind: Kustomization
 resources:
   - ./secrets.sops.yaml
   - ./helm-release.yaml
-configMapGenerator:
-  - name: openclaw-configmap
-    files:
-      - ./resources/openclaw.json
-generatorOptions:
-  disableNameSuffixHash: true

--- a/cluster/apps/ai/openclaw/app/resources/openclaw.json
+++ b/cluster/apps/ai/openclaw/app/resources/openclaw.json
@@ -1,5 +1,0 @@
-{
-  "gateway": {
-    "trustedProxies": ["10.244.0.0/16"]
-  }
-}


### PR DESCRIPTION
#5029 fixed `proxy_attribution_required` by mounting a ConfigMap over `/home/node/.openclaw/openclaw.json` with just `gateway.trustedProxies` set. That was wrong: it **replaced** the real, already-onboarded config file (which had `gateway.mode` and other settings), so the gateway then refused to start with `existing config is missing gateway.mode`. Worse, the mount was read-only, so the `migrate` initContainer's `chown -R 1000:1000 /home/node/.openclaw` failed on that file and the pod got stuck in `Init:Error` — a total outage, worse than the original bug.

This PR:
- Removes the ConfigMap mount, `configMapGenerator`, and `resources/openclaw.json`.
- Adds a `node -e` merge step to the existing `migrate` initContainer: it reads the real `openclaw.json` from the PVC, adds `10.244.0.0/16` to `gateway.trustedProxies` if not already present, and writes it back — preserving every other key (`gateway.mode`, auth, etc.). If the file doesn't exist yet it starts from `{}`; if it fails to parse it skips the merge rather than clobbering anything.

Verified: rendered the kustomization (no ConfigMap, no stray `${VAR}` tokens beyond the already-escaped `$${agent}` and the pre-existing `${SECRET_DOMAIN}`), `sh -n` on the extracted script for syntax, and `task test:lint:all` (kubeconform: 0 invalid/0 errors).
