### PR TITLE
fix(openclaw): expect 403 in gatus health check

### DIFF
--- a/cluster/apps/ai/openclaw/app/helm-release.yaml
+++ b/cluster/apps/ai/openclaw/app/helm-release.yaml
@@ -100,6 +100,12 @@ spec:
         enabled: true
         annotations:
           gatus.io/enabled: "true"
+          # openclaw's gateway.trustedProxies covers the whole pod CIDR (needed so Traefik
+          # is trusted from any node), so an in-cluster caller like Gatus collides with that
+          # same range and gets rejected as an unattributable proxy hop — 403 is expected here.
+          gatus.io/endpoint: |
+            conditions:
+              - "[STATUS] == 403"
         parentRefs:
           - name: internal-gateway
             namespace: networking


### PR DESCRIPTION
## Summary
The Gatus check for openclaw was failing because openclaw's gateway rejects the health-check request with `403 proxy_attribution_required` — not because the app is unhealthy.

## Root cause
openclaw's `gateway.trustedProxies` is set to `10.244.0.0/16` (the whole pod CIDR) so Traefik is trusted regardless of which node it lands on. But that means an in-cluster caller like Gatus — whose own pod IP also falls inside `10.244.0.0/16` — collides with that same trust range: when its `X-Forwarded-For` hop is walked, openclaw treats the caller itself as "another trusted proxy" rather than the real client, exhausts the chain, and returns `403 {"type":"proxy_attribution_required"}`. Verified live: reproduced the identical 403 from an in-cluster pod hitting `https://openclaw.home.${SECRET_DOMAIN}/` via the same path Gatus uses, and confirmed real LAN clients (whose IPs aren't in the pod CIDR) aren't affected.

Since Traefik's replicas are scheduled across every node, there's no CIDR narrower than the whole pod range that would cover Traefik without also covering Gatus — this is a structural property of the flat pod network, not a misconfiguration to keep chasing.

## Fix
Override the generated Gatus endpoint condition to expect `[STATUS] == 403`, matching the existing repo convention for apps with legitimate non-200 defaults (plex → 401, toolhive → 406, flux-receiver → 404).

## Testing
- `mise x -- task test:lint:all` — passed (kubeconform 71/0 invalid, yamllint/prettier/paths clean)
- Verified against the live cluster: current Gatus check results for `openclaw` return 403 consistently; after this change the condition matches that response.