### PR TITLE
feat(toolhive): register mcp-kitinerary MCP server

### DIFF
--- a/cluster/apps/ai/toolhive/README.md
+++ b/cluster/apps/ai/toolhive/README.md
@@ -63,15 +63,16 @@ For AI frameworks running directly inside the Kubernetes cluster (e.g., **Open W
 
 ## Active MCP Tool Inventory
 
-| Server Name              | Purpose                                        | Credentials Source          |
-| :----------------------- | :--------------------------------------------- | :-------------------------- |
-| **`mcp-kubernetes`**     | Pod logs, crashes, events, resource status     | Cluster RBAC                |
-| **`mcp-github`**         | GitHub PRs, issues & workflow status           | `mcp-github-secret`         |
-| **`mcp-memory`**         | Persistent AI knowledge graph storage          | In-Memory / PVC             |
-| **`mcp-flux`**           | Flux GitOps reconciliation & drift auditing    | `mcp-flux` RBAC             |
-| **`mcp-home-assistant`** | Home Assistant IoT entity & automation control | `mcp-home-assistant-secret` |
-| **`mcp-arr-stack`**      | Sonarr, Radarr, Prowlarr management            | Flux Secrets / Env          |
-| **`mcp-pullmd`**         | Convert any URL to clean Markdown              | None (unauthenticated core) |
+| Server Name              | Purpose                                                                                  | Credentials Source          |
+| :----------------------- | :--------------------------------------------------------------------------------------- | :-------------------------- |
+| **`mcp-kubernetes`**     | Pod logs, crashes, events, resource status                                               | Cluster RBAC                |
+| **`mcp-github`**         | GitHub PRs, issues & workflow status                                                     | `mcp-github-secret`         |
+| **`mcp-memory`**         | Persistent AI knowledge graph storage                                                    | In-Memory / PVC             |
+| **`mcp-flux`**           | Flux GitOps reconciliation & drift auditing                                              | `mcp-flux` RBAC             |
+| **`mcp-home-assistant`** | Home Assistant IoT entity & automation control                                           | `mcp-home-assistant-secret` |
+| **`mcp-arr-stack`**      | Sonarr, Radarr, Prowlarr management                                                      | Flux Secrets / Env          |
+| **`mcp-pullmd`**         | Convert any URL to clean Markdown                                                        | None (unauthenticated core) |
+| **`mcp-kitinerary`**     | Extract schema.org Reservation JSON-LD from travel confirmation emails/PDFs/pkpass files | None (no network egress)    |
 
 ---
 

--- a/cluster/apps/ai/toolhive/servers/kustomization.yaml
+++ b/cluster/apps/ai/toolhive/servers/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
   - ./mcp-victoriametrics.yaml
   - ./mcp-grafana.yaml
   - ./mcp-kubesearch.yaml
+  - ./mcp-kitinerary.yaml
   - ./mcp-pullmd.yaml
   - ./virtualmcpserver.yaml

--- a/cluster/apps/ai/toolhive/servers/mcp-kitinerary.yaml
+++ b/cluster/apps/ai/toolhive/servers/mcp-kitinerary.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServer
+metadata:
+  name: mcp-kitinerary
+spec:
+  groupRef:
+    name: toolhive-servers
+  # Image source: https://github.com/mrwulf/kitinerary-mcp (standalone repo,
+  # per docs/kitinerary_mcp_server_spec.md §6 option 1). Wraps KDE's
+  # kitinerary-extractor CLI for deterministic schema.org Reservation
+  # JSON-LD extraction from travel confirmation emails/PDFs/pkpass files.
+  # renovate: depName=ghcr.io/mrwulf/kitinerary-mcp datasource=docker
+  image: ghcr.io/mrwulf/kitinerary-mcp:v0.1.0
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  # No secrets, no outbound network calls, no persistent state - each call
+  # is an isolated CLI invocation against a temp file in the emptyDir below.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    # CPU limits omitted per cluster rule #6
+    limits:
+      memory: 256Mi
+  podTemplateSpec:
+    metadata:
+      annotations:
+        reloader.stakater.com/auto: "true"
+    spec:
+      containers:
+        - name: mcp
+          # This podTemplateSpec container entry replaces the whole
+          # container spec rather than field-merging onto it, so `resources`
+          # must be repeated here too (see mcp-pullmd.yaml for the same
+          # verified behavior) or the operator silently drops it.
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10001
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: TMPDIR
+              value: /tmp/kitinerary
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp/kitinerary
+      # emptyDir, not a PVC: the extraction temp file is fully disposable
+      # and cleaned up by the server itself after every call.
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
Implements the ToolHive registration half of docs/kitinerary_mcp_server_spec.md (§8) — the image itself was built and published separately at https://github.com/mrwulf/kitinerary-mcp (spec §6, option 1: standalone repo).

## What's here

- `cluster/apps/ai/toolhive/servers/mcp-kitinerary.yaml` — new `MCPServer`, `stdio` transport, no secrets, no persistent volume (an `emptyDir` backs the extraction temp file). Hardened per spec §5: non-root UID 10001, all capabilities dropped, `readOnlyRootFilesystem: true`.
- Registered in `servers/kustomization.yaml`.
- `README.md` Active MCP Tool Inventory table updated.

Image: `ghcr.io/mrwulf/kitinerary-mcp:v0.1.0` — public, pinned exact tag (never `latest`), confirmed pullable without auth. Renovate's existing `docker` datasource manager tracks this tag going forward with no new config (spec §7.1); the trickier apt-package pin for `libkitinerary-bin`/`libkitinerary-data` and its `customManagers` regex live inside the image repo's own `Dockerfile`, not here.

`mise x -- task test:all` passes.