### PR TITLE
feat(ingress-vps): terminate TLS at the edge, default to Cloudflare Tunnel

### DIFF
--- a/.taskfiles/test.yml
+++ b/.taskfiles/test.yml
@@ -68,7 +68,7 @@ tasks:
     desc: Statically validate OpenTofu manifests
     cmds:
       - |
-        for dir in cluster/apps/networking/ingress-vps/us cluster/apps/networking/ingress-vps/eu cluster/apps/networking/ingress-vps/failover; do
+        for dir in cluster/apps/networking/ingress-vps/us cluster/apps/networking/ingress-vps/eu cluster/apps/networking/ingress-vps/failover cluster/apps/networking/ingress-vps/failover-fast; do
           echo "Validating OpenTofu module in $dir..."
           (cd "{{.PROJECT_DIR}}/$dir" && rm -rf .terraform && tofu init -backend=false && tofu validate && rm -rf .terraform) || exit 1
         done

--- a/cluster/apps/backups/restic-rest-server/app/helm-release.yaml
+++ b/cluster/apps/backups/restic-rest-server/app/helm-release.yaml
@@ -111,6 +111,10 @@ spec:
       main:
         enabled: true
         annotations:
+          # Large backup uploads: keep on the VPS/raw-TCP path rather than the
+          # Cloudflare-Tunnel-primary default (see cluster/apps/networking/traefik/external/gateway.yaml).
+          # Also avoids Cloudflare's free-tier upload size/timeout limits on large snapshots.
+          external-dns.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
           gatus.io/enabled: "true"
           gatus.io/endpoint: |
             conditions:

--- a/cluster/apps/household/immich/app/proxy-helm-release.yaml
+++ b/cluster/apps/household/immich/app/proxy-helm-release.yaml
@@ -43,9 +43,8 @@ spec:
       main:
         enabled: true
         annotations:
-          # Large media uploads/downloads: keep on the VPS/raw-TCP path rather than the
-          # Cloudflare-Tunnel-primary default (see cluster/apps/networking/traefik/external/gateway.yaml).
-          external-dns.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
+          # Sharing-only, no uploads through this endpoint: fine on the Cloudflare-Tunnel-primary
+          # default (see cluster/apps/networking/traefik/external/gateway.yaml), unlike photos.${SECRET_DOMAIN}.
           gatus.io/enabled: "true"
         parentRefs:
           - name: external-gateway

--- a/cluster/apps/household/immich/app/proxy-helm-release.yaml
+++ b/cluster/apps/household/immich/app/proxy-helm-release.yaml
@@ -43,6 +43,9 @@ spec:
       main:
         enabled: true
         annotations:
+          # Large media uploads/downloads: keep on the VPS/raw-TCP path rather than the
+          # Cloudflare-Tunnel-primary default (see cluster/apps/networking/traefik/external/gateway.yaml).
+          external-dns.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
           gatus.io/enabled: "true"
         parentRefs:
           - name: external-gateway

--- a/cluster/apps/household/immich/app/server-helm-release.yaml
+++ b/cluster/apps/household/immich/app/server-helm-release.yaml
@@ -86,6 +86,9 @@ spec:
       main:
         enabled: true
         annotations:
+          # Large media uploads/downloads: keep on the VPS/raw-TCP path rather than the
+          # Cloudflare-Tunnel-primary default (see cluster/apps/networking/traefik/external/gateway.yaml).
+          external-dns.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
           gatus.io/enabled: "true"
         parentRefs:
           - name: external-gateway

--- a/cluster/apps/media/plex/app/helm-release.yaml
+++ b/cluster/apps/media/plex/app/helm-release.yaml
@@ -92,6 +92,9 @@ spec:
       main:
         enabled: true
         annotations:
+          # Large sustained media streams: keep on the VPS/raw-TCP path rather than the
+          # Cloudflare-Tunnel-primary default (see cluster/apps/networking/traefik/external/gateway.yaml).
+          external-dns.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
           gatus.io/enabled: "true"
           gatus.io/endpoint: |
             conditions:

--- a/cluster/apps/monitoring/gatus/app/resources/config.yaml
+++ b/cluster/apps/monitoring/gatus/app/resources/config.yaml
@@ -141,9 +141,9 @@ endpoints:
     ui:
       hide-hostname: true
       hide-url: true
-  - name: External Public Ingress via VPS
+  - name: VPS-Primary Ingress (excluded apps)
     group: external
-    url: "https://proxy.${SECRET_DOMAIN}"
+    url: "https://ingress.${SECRET_DOMAIN}"
     interval: 2m
     conditions:
       - "[STATUS] == 418"
@@ -151,7 +151,17 @@ endpoints:
     ui:
       hide-hostname: true
       hide-url: true
-  - name: External Backup Ingress via Cloudflare Tunnel
+  - name: Fast Ingress via Cloudflare Tunnel (primary)
+    group: external
+    url: "https://fast.${SECRET_DOMAIN}"
+    interval: 2m
+    conditions:
+      - "[STATUS] == 418"
+    alerts: *alerts
+    ui:
+      hide-hostname: true
+      hide-url: true
+  - name: Cloudflare Tunnel Direct
     group: external
     url: "https://external.${SECRET_DOMAIN}"
     interval: 2m

--- a/cluster/apps/networking/ingress-vps/app/tofu.yaml
+++ b/cluster/apps/networking/ingress-vps/app/tofu.yaml
@@ -85,3 +85,33 @@ spec:
       name: cloudflare-ddns
     - kind: Secret
       name: ingress-tunnel-secrets
+---
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: ingress-vps-failover-fast
+  namespace: networking
+spec:
+  dependsOn:
+    - name: ingress-vps-failover
+      namespace: networking
+  interval: 5m
+  retryInterval: 1m
+  approvePlan: auto
+  destroyResourcesOnDeletion: true
+  path: ./cluster/apps/networking/ingress-vps/failover-fast
+  serviceAccountName: tf-runner
+  sourceRef:
+    kind: GitRepository
+    name: tofu-infra-git
+    namespace: networking
+  vars:
+    - name: cloudflare_tunnel_cname
+      value: "${SECRET_CLOUDFLARE_TUNNEL_ID}.cfargotunnel.com"
+    - name: secret_domain
+      value: "${SECRET_DOMAIN}"
+  varsFrom:
+    - kind: Secret
+      name: cloudflare-ddns
+    - kind: Secret
+      name: ingress-tunnel-secrets

--- a/cluster/apps/networking/ingress-vps/app/vps-direct-route.yaml
+++ b/cluster/apps/networking/ingress-vps/app/vps-direct-route.yaml
@@ -14,8 +14,6 @@ spec:
     - "vps-us.${SECRET_DOMAIN}"
     - "vps-eu.${SECRET_DOMAIN}"
     - "proxy.${SECRET_DOMAIN}"
-    - "proxy-us.${SECRET_DOMAIN}"
-    - "proxy-eu.${SECRET_DOMAIN}"
     - "ingress.${SECRET_DOMAIN}"
     - "fast.${SECRET_DOMAIN}"
     - "external.${SECRET_DOMAIN}"

--- a/cluster/apps/networking/ingress-vps/app/vps-direct-route.yaml
+++ b/cluster/apps/networking/ingress-vps/app/vps-direct-route.yaml
@@ -13,8 +13,10 @@ spec:
   hostnames:
     - "vps-us.${SECRET_DOMAIN}"
     - "vps-eu.${SECRET_DOMAIN}"
-    - "proxy.${SECRET_DOMAIN}"
+    - "proxy-us.${SECRET_DOMAIN}"
+    - "proxy-eu.${SECRET_DOMAIN}"
     - "ingress.${SECRET_DOMAIN}"
+    - "fast.${SECRET_DOMAIN}"
     - "external.${SECRET_DOMAIN}"
   rules:
     - backendRefs:

--- a/cluster/apps/networking/ingress-vps/app/vps-direct-route.yaml
+++ b/cluster/apps/networking/ingress-vps/app/vps-direct-route.yaml
@@ -13,6 +13,7 @@ spec:
   hostnames:
     - "vps-us.${SECRET_DOMAIN}"
     - "vps-eu.${SECRET_DOMAIN}"
+    - "proxy.${SECRET_DOMAIN}"
     - "proxy-us.${SECRET_DOMAIN}"
     - "proxy-eu.${SECRET_DOMAIN}"
     - "ingress.${SECRET_DOMAIN}"

--- a/cluster/apps/networking/ingress-vps/eu/.terraform.lock.hcl
+++ b/cluster/apps/networking/ingress-vps/eu/.terraform.lock.hcl
@@ -99,6 +99,80 @@ provider "registry.opentofu.org/hashicorp/kubernetes" {
   ]
 }
 
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.3.1"
+  constraints = "~> 3.2"
+  hashes = [
+    "h1:2wld81FnmHW0WVgy081sIfokCr2+NuatS8yjeLEet7Y=",
+    "h1:AClQjJ6X22V4qcRgcYSxiXCMmp2pz0G8WVQC7wAx66o=",
+    "h1:AY3XQbuviNd2X5VhHYEbhNta1m/CG3JD2BKFKhCt1Y4=",
+    "h1:CUOZUd7H11lsU+4tISlnYIiP5BqnX8IDwFCVqfLJyAg=",
+    "h1:JIfV0nA/pLWnIFGscvTfuavQCn2NeHxJBeb6UUg/joA=",
+    "h1:RejAh+nyCwqDGExGln2Kb4Ro5LyHak0eJe0P9g8CHPc=",
+    "h1:SHOuTZjYymsmy4asuRq6NC3yW+zdVZOOt4f5nrb+EPM=",
+    "h1:WwPat/gT4gO8GvvKNdSkkXWVD65JppLJfqKOt9HhOqQ=",
+    "h1:Z3hXVLrOyaRiiLmmL5UCOdcRMguwjN1x5TYNdmBDgls=",
+    "h1:dd78Ad5HdfPzPts7A9qIxfitXhAriV/qza38fr2ukjk=",
+    "h1:dyVb++KwDdybzLTE6bf7GZiVQ31iWsgKPWmhTQ8G42k=",
+    "h1:gD8ZH6WWe+5gg5+y8SpLWGPUDzSxcQ3HKP8IDM/wW3I=",
+    "h1:juXCww0zRQKFTDZoKqYR0+Sn1lu99oeL6pr0Jh6LWx0=",
+    "h1:kFAySmtsshyNV7IhIrEdASzVcvwy68eeZCVC66P7yNk=",
+    "h1:nS5azDopRisB2NInwDx3Hrfg2FdVt8Gw0gTQzC0rd70=",
+    "zh:164eb061d84e01759f391265865fb31828083d0a06b25f7af7e094cbdb18c799",
+    "zh:1bb9b669a82b52c0cba2860c71e9ee6699ef302f28cb8ed06f572d39bc6c7c4f",
+    "zh:1ea9b31a8f29302122c1e8d673693f3ac270336dae560af803cd1117265a469a",
+    "zh:238bd463cb0154fb935dc331da40c0a9cbe5db9cee615ae5f35ccad5eed7dc41",
+    "zh:30ef2b7384cf7e20f33fe75754b54cf669d59816f3ad4fc73bfb2b26fb6735e9",
+    "zh:35b5cded16e4b57c207d03ee0979b14baf486fa520e6edb7a2eecf18f1b85471",
+    "zh:3dc840d13a50cd215c7540573f27e2b61f739ba90aee5b7c3846079aa0ab5534",
+    "zh:3f9309a18db608f975d5691fcb47a6e14d77199156a52e9c39dcafe3737f2b07",
+    "zh:44263a219f7dbd1848b545d080110b4f7d0495e77b71cd3c7a0b5ec52a09accb",
+    "zh:4dec54aa5f445eeea035bbd4839bcded5e47ecd07cba0e70c5a09e9272cb592f",
+    "zh:5e8fb319d7c6d6c4566a18b9d0c91580b4901a96acd7fdc476bfc79f074368e2",
+    "zh:b0e8b6d41834b57fcfbb5ca00da52ccb757e1a95b6a2d546c0dae8bfbeca1cdf",
+    "zh:bbde4c3a1dcc1718027a61a4cdf661619d17af1b58df1038fe27bcf43c3dc29b",
+    "zh:c4140fff9f692baf29236557f706f9515f93229413438527d764023a82301da3",
+    "zh:f8e9d83184e4bbeb97c6f0d569833007c48ba5a7ff334def201df4991d03a962",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/tls" {
+  version     = "4.4.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:37OPfmlziRrBgEz2oZEYOSvANEjFtDZK8S7CXchV6hg=",
+    "h1:8KHKh+WnimOwrte+RK3fDNX3wM14fUbKL6alOHhS8G0=",
+    "h1:B7yGz4mpkSlsqxC7+4ZhWft49zF42wphoGYeXM3vMIo=",
+    "h1:Eb+WGv4GM+Wad6XQPBY4yKIzledal6lhQYaw5NXMNvk=",
+    "h1:QQHdl1Dd5WiZx3vZhvHo8FYyte49JODt0PaFoJnGDLk=",
+    "h1:Ts5hrfNaAKPw6gX0SLHJrOFXDwIo/eW20ePuU7mL5e8=",
+    "h1:ZHcWyrqBZK/wh4wSPScMnNtf0k9BGe0TIE7GQ28oJK0=",
+    "h1:a6wTdpC0rNTeQ5wQSzSggnBqYbElNcq6ZjZfvwT5ivE=",
+    "h1:hdZOgvtirMaflk1GOVMUxYw2g0tRDbgELbjjxbDm6dY=",
+    "h1:hmiQdLrPJpUB2bzKAXZnQ5dcvwRA9MqB0mWpdlhkBIw=",
+    "h1:i9X1kPBpE8gP6hDu8V0bfjDKdaIAdnwWGePJARunXlM=",
+    "h1:iZBNaQrjv5pc1ZK83nDHQluFx5KjyxagzWtr5ggnSH8=",
+    "h1:q/ZAqq4V1gxd72nVs1/URKx2XIPtGrq3YgE/Jtp5kl4=",
+    "h1:q7lks7YmQ4pi5TQ0PR6BLGxXnjBMv4NvjcvvtuelHI0=",
+    "h1:q8l99jPnlD8ys9jsQQknLCaYrA1NTNwirzFfEOrjxFI=",
+    "zh:0f715faf86fc318c31ef0bbe591c148d359e0aaabd5410435503dd6f71f2ea6c",
+    "zh:15e748a856d4f6e751c98125f08599a1be997296ce40a7fc19109c99d95a8639",
+    "zh:60c917163488bddc83efdc7a87b2a6b3dc589c3aedab6ff5da3c719aaf26fb61",
+    "zh:6a2ea5fe39fb47a3eb112e85a513a229fc4dc69cac742d656dd36ce986ffa8bf",
+    "zh:6c5c0d242a59f127f4c833dab41cc827a98e9a5081e9efed2de7a33355c8420f",
+    "zh:82da7ec5151b2e7fefa2279180fa408af7f35cdb3ce41d5b918bca60c74bb19d",
+    "zh:8e4821e874d9ddf6636de6b1f0cd0319fb759d707ff8a2a1edf692ede77bd10f",
+    "zh:96fb4be355b175410edc83399dbc9439c351efb8542a70c9314aa2c6ee6800f2",
+    "zh:9c1f608a4743aaa3567859ac3c00c13173022fe571aa06ecb9d32239a8fc891a",
+    "zh:a36197d236af47e5d16143384559879b96aa47f2d6c68a805dd64eeaab2901c4",
+    "zh:d40089905435cff7a508d783bf66b50c54d8619c1f1dad2bedf4822ab22826d7",
+    "zh:e344c7a0ab62b1d21340258cbcb4bbc3fe41281347d7aff0b8900e5944427183",
+    "zh:f1263e791fee7229bf16114f875ec7ff4db8e6727db914715d903fc377168522",
+    "zh:f3bfab9d65bfd3a553e584f40f94f8827230a6c12a11e813351c6365f58be96e",
+    "zh:fcf6e1d3a86a3f0c8aabbdededb5ad4f494236741677aedff48023468e18b0f8",
+  ]
+}
+
 provider "registry.opentofu.org/hetznercloud/hcloud" {
   version     = "1.68.0"
   constraints = "~> 1.45"

--- a/cluster/apps/networking/ingress-vps/eu/main.tf
+++ b/cluster/apps/networking/ingress-vps/eu/main.tf
@@ -260,8 +260,18 @@ resource "cloudflare_dns_record" "vps_eu" {
   ttl     = 1
 }
 
-# Proxy IPv4 A record for EU VPS (region-specific: see note on proxy_us in us/main.tf)
+# Proxy IPv4 A record for EU VPS (shared round-robin name: see note on proxy_us in us/main.tf)
 resource "cloudflare_dns_record" "proxy_eu" {
+  zone_id = data.cloudflare_zones.domain_zones.result[0].id
+  name    = "proxy.${var.secret_domain}"
+  content = hcloud_server.eu_vps.ipv4_address
+  type    = "A"
+  proxied = false
+  ttl     = 1
+}
+
+# Region-specific record (not client-facing): see note on proxy_us_only in us/main.tf
+resource "cloudflare_dns_record" "proxy_eu_only" {
   zone_id = data.cloudflare_zones.domain_zones.result[0].id
   name    = "proxy-eu.${var.secret_domain}"
   content = hcloud_server.eu_vps.ipv4_address

--- a/cluster/apps/networking/ingress-vps/eu/main.tf
+++ b/cluster/apps/networking/ingress-vps/eu/main.tf
@@ -54,6 +54,14 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 3.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
   }
 }
 
@@ -84,6 +92,27 @@ data "cloudflare_zones" "domain_zones" {
   name = var.secret_domain
 }
 
+# Read the cluster's cert-manager-issued wildcard cert so TF can push it to the
+# VPS whenever it renews, without that being part of the (replace-triggering)
+# instance user_data.
+data "kubernetes_secret_v1" "wildcard_cert" {
+  metadata {
+    name      = "wildcard-${replace(var.secret_domain, ".", "-")}-tls"
+    namespace = "networking"
+  }
+}
+
+# Dedicated automation keypair for TF-driven post-boot provisioning (cert/whitelist
+# pushes). Kept separate from the human keys picked up via data.hcloud_ssh_keys below.
+resource "tls_private_key" "tf_admin" {
+  algorithm = "ED25519"
+}
+
+resource "hcloud_ssh_key" "tf_admin" {
+  name       = "ingress-vps-eu-tf-admin-key"
+  public_key = tls_private_key.tf_admin.public_key_openssh
+}
+
 # Hetzner Cloud EU Ingress VPS
 data "hcloud_ssh_keys" "all_keys" {}
 
@@ -95,12 +124,12 @@ resource "terraform_data" "cloud_init_eu" {
       NETBIRD_SELFHOSTED_MGMT_URL  = "https://nb.${var.secret_domain}"
       NETBIRD_RELAY_AUTH_SECRET    = var.netbird_relay_auth_secret
       SECRET_DOMAIN                = var.secret_domain
-      HOME_IP                      = local.home_ip
       PROBE_HOSTNAME               = "vps-eu.${var.secret_domain}"
       WG_PRIVATE_KEY               = var.peer_eu_private_key
       WG_PEER_PUBLIC_KEY           = var.wg_public_key
       WG_ADDRESS                   = "10.13.13.11/32"
       NB_ADDR                      = "10.0.10.11"
+      TF_ADMIN_SSH_PUBLIC_KEY      = tls_private_key.tf_admin.public_key_openssh
     })
   }
 }
@@ -110,7 +139,7 @@ resource "hcloud_server" "eu_vps" {
   image       = "debian-${split(".", local.debian_version)[0]}"
   server_type = "cx23"
   location    = "nbg1" # Nuremberg, Germany (Includes 20TB traffic limit)
-  ssh_keys    = data.hcloud_ssh_keys.all_keys.ssh_keys[*].id
+  ssh_keys    = concat(data.hcloud_ssh_keys.all_keys.ssh_keys[*].id, [hcloud_ssh_key.tf_admin.id])
 
   public_net {
     ipv4_enabled = true
@@ -231,10 +260,10 @@ resource "cloudflare_dns_record" "vps_eu" {
   ttl     = 1
 }
 
-# Proxy IPv4 A record for EU VPS
+# Proxy IPv4 A record for EU VPS (region-specific: see note on proxy_us in us/main.tf)
 resource "cloudflare_dns_record" "proxy_eu" {
   zone_id = data.cloudflare_zones.domain_zones.result[0].id
-  name    = "proxy.${var.secret_domain}"
+  name    = "proxy-eu.${var.secret_domain}"
   content = hcloud_server.eu_vps.ipv4_address
   type    = "A"
   proxied = false
@@ -277,6 +306,96 @@ resource "kubernetes_secret_v1" "vps_eu_output_flux" {
 
   data = {
     VPS_EU_PUBLIC_IP = hcloud_server.eu_vps.ipv4_address
+  }
+
+  depends_on = [
+    data.http.vps_eu_healthcheck
+  ]
+}
+
+# Push the current cert-manager wildcard cert to the VPS and reload Traefik.
+# Triggered only by cert content, so a renewal never touches user_data / replaces the instance.
+resource "null_resource" "cert_sync" {
+  triggers = {
+    cert_hash = sha256(join("", [
+      data.kubernetes_secret_v1.wildcard_cert.data["tls.crt"],
+      data.kubernetes_secret_v1.wildcard_cert.data["tls.key"],
+    ]))
+  }
+
+  connection {
+    type        = "ssh"
+    host        = hcloud_server.eu_vps.ipv4_address
+    user        = "root"
+    private_key = tls_private_key.tf_admin.private_key_openssh
+    timeout     = "2m"
+  }
+
+  provisioner "file" {
+    content     = data.kubernetes_secret_v1.wildcard_cert.data["tls.crt"]
+    destination = "/tmp/tls.crt"
+  }
+
+  provisioner "file" {
+    content     = data.kubernetes_secret_v1.wildcard_cert.data["tls.key"]
+    destination = "/tmp/tls.key"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "install -o root -g root -m 0644 /tmp/tls.crt /etc/traefik/certs/tls.crt",
+      "install -o root -g root -m 0600 /tmp/tls.key /etc/traefik/certs/tls.key",
+      "rm -f /tmp/tls.crt /tmp/tls.key",
+      "systemctl restart traefik",
+    ]
+  }
+
+  depends_on = [
+    data.http.vps_eu_healthcheck
+  ]
+}
+
+# Push the current home egress IP into CrowdSec's whitelist and reload it in place.
+# Triggered only by home_ip, so a residential IP change never touches user_data / replaces the instance.
+resource "null_resource" "home_ip_whitelist_sync" {
+  triggers = {
+    home_ip = local.home_ip
+  }
+
+  connection {
+    type        = "ssh"
+    host        = hcloud_server.eu_vps.ipv4_address
+    user        = "root"
+    private_key = tls_private_key.tf_admin.private_key_openssh
+    timeout     = "2m"
+  }
+
+  provisioner "file" {
+    content     = <<-EOF
+      name: local/whitelist
+      description: "Whitelist trusted IPs and internal networks"
+      filter: "1 == 1"
+      whitelist:
+        reason: "Whitelisted home IP and internal overlay networks"
+        ip:
+          - "${local.home_ip}"
+          - "127.0.0.1"
+          - "::1"
+        cidr:
+          - "100.64.0.0/10"
+          - "10.0.0.0/8"
+          - "172.16.0.0/12"
+          - "192.168.0.0/16"
+    EOF
+    destination = "/tmp/00-whitelist.yaml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "install -o root -g root -m 0644 /tmp/00-whitelist.yaml /etc/crowdsec/parsers/s02-enrich/00-whitelist.yaml",
+      "rm -f /tmp/00-whitelist.yaml",
+      "docker exec crowdsec cscli reload",
+    ]
   }
 
   depends_on = [

--- a/cluster/apps/networking/ingress-vps/eu/main.tf
+++ b/cluster/apps/networking/ingress-vps/eu/main.tf
@@ -270,15 +270,8 @@ resource "cloudflare_dns_record" "proxy_eu" {
   ttl     = 1
 }
 
-# Region-specific record (not client-facing): see note on proxy_us_only in us/main.tf
-resource "cloudflare_dns_record" "proxy_eu_only" {
-  zone_id = data.cloudflare_zones.domain_zones.result[0].id
-  name    = "proxy-eu.${var.secret_domain}"
-  content = hcloud_server.eu_vps.ipv4_address
-  type    = "A"
-  proxied = false
-  ttl     = 1
-}
+# Note: no separate region-specific "proxy-eu" record — vps-eu.${domain} below already
+# is one (single IP, same content), so the failover workers just target that directly.
 
 # Output EU VPS public IP
 output "VPS_EU_PUBLIC_IP" {

--- a/cluster/apps/networking/ingress-vps/eu/vps-cloud-init.yaml
+++ b/cluster/apps/networking/ingress-vps/eu/vps-cloud-init.yaml
@@ -1,4 +1,7 @@
 #cloud-config
+ssh_authorized_keys:
+  - ${TF_ADMIN_SSH_PUBLIC_KEY}
+
 write_files:
   # 1. Write Traefik Edge Ingress Proxy Static Configuration
   - path: /etc/traefik/traefik.yaml
@@ -9,12 +12,18 @@ write_files:
           address: ":80"
         websecure:
           address: ":443"
+          transport:
+            respondingTimeouts:
+              readTimeout: 3600s
+              idleTimeout: 3600s
+              writeTimeout: 3600s
         metrics:
           address: ":8082"
 
       providers:
         file:
           filename: "/etc/traefik/dynamic.yaml"
+          watch: true
 
       metrics:
         prometheus:
@@ -25,7 +34,11 @@ write_files:
 
       accessLog: {}
 
-  # 2. Write Traefik Edge Ingress Proxy Dynamic Configuration (SNI TLS Passthrough to K8s)
+  # 2. Write Traefik Edge Ingress Proxy Dynamic Configuration (TLS terminated at the
+  #    edge, forwarded to the cluster's own websecure entrypoint over the wg0 tunnel;
+  #    wg0 already encrypts that leg, and terminating here lets Traefik pool/reuse the
+  #    backend connection instead of paying a full TLS handshake over the tunnel per
+  #    client request, and gives CrowdSec real HTTP visibility instead of opaque TCP.
   - path: /etc/traefik/dynamic.yaml
     permissions: "0644"
     content: |
@@ -36,28 +49,33 @@ write_files:
               - web
             rule: "HostRegexp(`{host:.+}`)"
             service: k8s-http
+          websecure-catchall:
+            entryPoints:
+              - websecure
+            rule: "HostRegexp(`{host:.+}`)"
+            service: k8s-https
+            tls: {}
         services:
           k8s-http:
             loadBalancer:
               servers:
                 - url: "http://10.0.10.20:80"
-
-      tcp:
-        routers:
-          sni-passthrough:
-            entryPoints:
-              - websecure
-            rule: "HostSNI(`*`)"
-            service: k8s-traefik
-            tls:
-              passthrough: true
-        services:
-          k8s-traefik:
+          k8s-https:
             loadBalancer:
-              proxyProtocol:
-                version: 2
               servers:
-                - address: "10.0.10.20:443"
+                - url: "https://10.0.10.20:443"
+              serversTransport: k8s-internal
+        serversTransports:
+          k8s-internal:
+            # The cluster's own websecure listener already terminates the same
+            # wildcard cert; skip verification because the transport itself (WireGuard)
+            # is what actually authenticates this leg, not the TLS handshake.
+            insecureSkipVerify: true
+
+      tls:
+        certificates:
+          - certFile: /etc/traefik/certs/tls.crt
+            keyFile: /etc/traefik/certs/tls.key
 
   # 3. Write Traefik Systemd Container Service
   - path: /etc/systemd/system/traefik.service
@@ -226,7 +244,7 @@ runcmd:
     export DEBIAN_FRONTEND=noninteractive
     while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 2; done
     for i in $(seq 1 5); do
-      if apt-get update && apt-get install -y -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" docker.io systemd-resolved gnupg apt-transport-https wireguard-tools curl; then
+      if apt-get update && apt-get install -y -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" docker.io systemd-resolved gnupg apt-transport-https wireguard-tools curl openssl; then
         break
       fi
       sleep 3
@@ -280,6 +298,16 @@ runcmd:
   - echo "net.ipv4.tcp_keepalive_probes=3" >> /etc/sysctl.conf
   - echo "net.ipv4.tcp_retries2=5" >> /etc/sysctl.conf
 
+  # 5b. Bootstrap a self-signed cert so Traefik has something to serve on first boot;
+  #     the real wildcard cert is pushed moments later by the Terraform cert_sync provisioner.
+  - mkdir -p /etc/traefik/certs
+  - |
+    if [ ! -f /etc/traefik/certs/tls.crt ]; then
+      openssl req -x509 -nodes -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+        -keyout /etc/traefik/certs/tls.key -out /etc/traefik/certs/tls.crt \
+        -days 7 -subj "/CN=bootstrap.${SECRET_DOMAIN}"
+    fi
+
   # 6. Enable and start NetBird, NetBird Relay, Traefik, Node Exporter & CrowdSec Container
   - mkdir -p /var/lib/crowdsec/data
   - systemctl daemon-reload
@@ -310,6 +338,9 @@ runcmd:
     fi
 
   # 5. Wait for CrowdSec container to populate base /etc/crowdsec/config.yaml and write custom whitelist/acquisition
+  #    (bootstrap-only: no home IP yet, that's pushed in place by the Terraform
+  #    home_ip_whitelist_sync provisioner right after this instance comes up, and again
+  #    any time it changes, without ever replacing the instance)
   - |
     until docker exec crowdsec cscli config show >/dev/null 2>&1; do sleep 2; done
 
@@ -320,9 +351,8 @@ runcmd:
     description: "Whitelist trusted IPs and internal networks"
     filter: "1 == 1"
     whitelist:
-      reason: "Whitelisted home IP and internal overlay networks"
+      reason: "Whitelisted internal overlay networks"
       ip:
-        - "${HOME_IP}"
         - "127.0.0.1"
         - "::1"
       cidr:

--- a/cluster/apps/networking/ingress-vps/eu/vps-cloud-init.yaml
+++ b/cluster/apps/networking/ingress-vps/eu/vps-cloud-init.yaml
@@ -35,8 +35,10 @@ write_files:
       accessLog: {}
 
   # 2. Write Traefik Edge Ingress Proxy Dynamic Configuration (TLS terminated at the
-  #    edge, forwarded to the cluster's own websecure entrypoint over the wg0 tunnel;
-  #    wg0 already encrypts that leg, and terminating here lets Traefik pool/reuse the
+  #    edge, forwarded to the cluster's own websecure entrypoint over wt0 (NetBird's
+  #    tunnel, terminating on routing-peer pods inside the cluster - not wg0, which is
+  #    scoped to NB_ADDR/32 only, for bootstrapping enrollment, and can't reach it).
+  #    wt0 already encrypts that leg, and terminating here lets Traefik pool/reuse the
   #    backend connection instead of paying a full TLS handshake over the tunnel per
   #    client request, and gives CrowdSec real HTTP visibility instead of opaque TCP.
   - path: /etc/traefik/dynamic.yaml

--- a/cluster/apps/networking/ingress-vps/failover-fast/.terraform.lock.hcl
+++ b/cluster/apps/networking/ingress-vps/failover-fast/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "5.24.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:EdatAvZg845pGYfEdzYNkxmQfV8or5y6HDbh6CIJfI8=",
+    "h1:F3V4hF42Y/Usl9OhzNFQHwUL8oNXTzbY5x6dQaDaASc=",
+    "h1:HR6WGGeB70a/yygHbNFsg+3Ko7s9AgtlkFf8PdbZfT8=",
+    "h1:NxZYEFjCgaI7lGi3L8mn0KZcWPfbqUdmt5Bo4yqWMFE=",
+    "h1:PIAng5QYiHeydJm1S6sG6d1YYIjaFuIwnifvq/qEV1Q=",
+    "h1:R1Pt6vcenzSH8FDbxW1MQ3tk+/nXAfvscASTFaOmERM=",
+    "h1:ZGuBr8oAhWpWIni1jaNofXcsNUoaHuejjHcbcH72z1Q=",
+    "h1:yM0PvkOY7H66+yk+vlDJOnhDQXOFT6cHlmZ/C6UjT/c=",
+    "zh:2390fc5df95addfd47d3f638964a1f9f6192a8c84ad3b1eab554ef88e0ac4091",
+    "zh:2b09c0afbebeb3139a3094e3debda1ba5ff3d73b6eca536549bdc903284b6798",
+    "zh:3241ce471f20745b1dc93baea73a716e1db4637ff41acc134114b7a8c9684714",
+    "zh:3513243e5582836054076a21abeadd8142a8421df6ec1ead53d96dc37a9e6326",
+    "zh:99b33ccb8a1c10a08e8903a2848eb2664c889dc79801a1e61e0373dd41c6c0f9",
+    "zh:99c7b510b100a605b0c80e0c3665d99c2381b0834f52ad6ca767e161c2ffa416",
+    "zh:c523d747a2d8457bc2d2cc00967c419ef38a5ebebd12d5091cf18322b7201f04",
+    "zh:f520e37f4d875b6fee95cffb74cf5fe9efc3cd54fe6bb4b815da5cee87e517e8",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/cluster/apps/networking/ingress-vps/failover-fast/fast-failover-monitor.js
+++ b/cluster/apps/networking/ingress-vps/failover-fast/fast-failover-monitor.js
@@ -172,6 +172,8 @@ export default {
     const RECORD_NAME = env.RECORD_NAME
     const SECRET_DOMAIN = RECORD_NAME.replace(/^fast\./, "")
     const TUNNEL_CNAME = env.TUNNEL_CNAME
+    const PROXY_ROUND_ROBIN_CNAME =
+      env.PROXY_ROUND_ROBIN_CNAME || `proxy.${SECRET_DOMAIN}`
     const PROXY_US_CNAME = env.PROXY_US_CNAME || `proxy-us.${SECRET_DOMAIN}`
     const PROXY_EU_CNAME = env.PROXY_EU_CNAME || `proxy-eu.${SECRET_DOMAIN}`
     const ZONE_ID = env.CLOUDFLARE_ZONE_ID
@@ -200,45 +202,42 @@ export default {
       )
     } else {
       console.warn(
-        `Cloudflare Tunnel (${TUNNEL_HOST}) is UNHEALTHY. Probing US VPS (${VPS_US_HOST})...`
+        `Cloudflare Tunnel (${TUNNEL_HOST}) is UNHEALTHY. Probing both VPS regions...`
       )
 
-      // 2. Probe Tier 2: US VPS (OVHcloud)
+      // 2/3. Tunnel down: probe both regions (not short-circuited) so we can prefer
+      // the round-robin record when both happen to be healthy.
       const usProbe = await probeHost(VPS_US_HOST)
       allProbeLogs.push(...usProbe.attempts)
+      const euProbe = await probeHost(VPS_EU_HOST)
+      allProbeLogs.push(...euProbe.attempts)
 
-      if (usProbe.isUp) {
+      if (usProbe.isUp && euProbe.isUp) {
+        targetContent = PROXY_ROUND_ROBIN_CNAME
+        targetTier = "US + EU (round-robin Proxy) — degraded, higher latency"
+        isProxied = false
+        degraded = true
+        console.log(
+          `Both VPS regions are healthy. Routing to ${PROXY_ROUND_ROBIN_CNAME}.`
+        )
+      } else if (usProbe.isUp) {
         targetContent = PROXY_US_CNAME
         targetTier =
           "US Region (OVHcloud VPS / Proxy) — degraded, higher latency"
         isProxied = false
         degraded = true
-        console.log(
-          `US VPS (${VPS_US_HOST}) is healthy. Routing to ${PROXY_US_CNAME}.`
-        )
+        console.log(`Only US VPS is healthy. Routing to ${PROXY_US_CNAME}.`)
+      } else if (euProbe.isUp) {
+        targetContent = PROXY_EU_CNAME
+        targetTier =
+          "EU Region (Hetzner VPS / Proxy) — degraded, higher latency"
+        isProxied = false
+        degraded = true
+        console.log(`Only EU VPS is healthy. Routing to ${PROXY_EU_CNAME}.`)
       } else {
-        console.warn(
-          `US VPS (${VPS_US_HOST}) is UNHEALTHY. Probing EU VPS (${VPS_EU_HOST})...`
+        console.error(
+          `Tunnel, US VPS, and EU VPS are ALL unhealthy! Leaving ${RECORD_NAME} unchanged and alerting.`
         )
-
-        // 3. Probe Tier 3: EU VPS (Hetzner)
-        const euProbe = await probeHost(VPS_EU_HOST)
-        allProbeLogs.push(...euProbe.attempts)
-
-        if (euProbe.isUp) {
-          targetContent = PROXY_EU_CNAME
-          targetTier =
-            "EU Region (Hetzner VPS / Proxy) — degraded, higher latency"
-          isProxied = false
-          degraded = true
-          console.log(
-            `EU VPS (${VPS_EU_HOST}) is healthy. Routing to ${PROXY_EU_CNAME}.`
-          )
-        } else {
-          console.error(
-            `Tunnel, US VPS, and EU VPS are ALL unhealthy! Leaving ${RECORD_NAME} unchanged and alerting.`
-          )
-        }
       }
     }
 

--- a/cluster/apps/networking/ingress-vps/failover-fast/fast-failover-monitor.js
+++ b/cluster/apps/networking/ingress-vps/failover-fast/fast-failover-monitor.js
@@ -1,5 +1,11 @@
 import { connect } from "cloudflare:sockets"
 
+// Cloudflare-primary counterpart to ../failover/failover-monitor.js: that worker
+// keeps ingress.${domain} VPS-primary for the apps carved out of this path (large
+// transfers / raw TCP needs). This one keeps fast.${domain} on the Cloudflare Tunnel
+// by default (single-digit-ms edge latency vs. several hundred ms through either VPS
+// region) and only falls back to a VPS if the tunnel itself is unreachable.
+
 async function sendEmailViaSMTP(env, from, to, subject, body) {
   let socket
   let writer
@@ -117,14 +123,14 @@ async function probeHost(host, maxProbes = 3) {
 
   for (let attempt = 1; attempt <= maxProbes; attempt++) {
     console.log(
-      `Probing direct endpoint https://${host} (attempt ${attempt}/${maxProbes})...`
+      `Probing endpoint https://${host} (attempt ${attempt}/${maxProbes})...`
     )
     const startTime = Date.now()
     try {
       const res = await fetch(`https://${host}`, {
         method: "HEAD",
         headers: {
-          "User-Agent": "Cloudflare-Worker-Failover-Monitor/1.0",
+          "User-Agent": "Cloudflare-Worker-Fast-Failover-Monitor/1.0",
         },
         signal: AbortSignal.timeout(5000),
       })
@@ -160,60 +166,79 @@ async function probeHost(host, maxProbes = 3) {
 
 export default {
   async scheduled(event, env, ctx) {
+    const TUNNEL_HOST = env.TUNNEL_HOST
     const VPS_US_HOST = env.VPS_US_HOST
     const VPS_EU_HOST = env.VPS_EU_HOST
     const RECORD_NAME = env.RECORD_NAME
-    const SECRET_DOMAIN = RECORD_NAME.replace(/^ingress\./, "")
+    const SECRET_DOMAIN = RECORD_NAME.replace(/^fast\./, "")
+    const TUNNEL_CNAME = env.TUNNEL_CNAME
     const PROXY_US_CNAME = env.PROXY_US_CNAME || `proxy-us.${SECRET_DOMAIN}`
     const PROXY_EU_CNAME = env.PROXY_EU_CNAME || `proxy-eu.${SECRET_DOMAIN}`
-    const TUNNEL_CNAME = env.TUNNEL_CNAME || `external.${SECRET_DOMAIN}`
     const ZONE_ID = env.CLOUDFLARE_ZONE_ID
     const RECORD_ID = env.CLOUDFLARE_RECORD_ID
     const API_TOKEN = env.CLOUDFLARE_API_TOKEN
 
-    const fromEmail = `failover-monitor@${SECRET_DOMAIN}`
+    const fromEmail = `fast-failover-monitor@${SECRET_DOMAIN}`
     const toEmail = `postmaster@${SECRET_DOMAIN}`
 
     const allProbeLogs = []
     let targetContent = null
     let targetTier = null
     let isProxied = false
+    let degraded = false
 
-    // 1. Probe Tier 1: US VPS (OVHcloud)
-    const usProbe = await probeHost(VPS_US_HOST)
-    allProbeLogs.push(...usProbe.attempts)
+    // 1. Probe Tier 1: Cloudflare Tunnel (default/primary — lowest latency, global anycast)
+    const tunnelProbe = await probeHost(TUNNEL_HOST)
+    allProbeLogs.push(...tunnelProbe.attempts)
 
-    if (usProbe.isUp) {
-      targetContent = PROXY_US_CNAME
-      targetTier = "US Region (OVHcloud VPS / Proxy)"
-      isProxied = false
+    if (tunnelProbe.isUp) {
+      targetContent = TUNNEL_CNAME
+      targetTier = "Cloudflare Tunnel"
+      isProxied = true
       console.log(
-        `US VPS (${VPS_US_HOST}) is healthy. Routing to ${PROXY_US_CNAME}.`
+        `Cloudflare Tunnel (${TUNNEL_HOST}) is healthy. Routing to ${TUNNEL_CNAME}.`
       )
     } else {
       console.warn(
-        `US VPS (${VPS_US_HOST}) is UNHEALTHY. Probing EU VPS (${VPS_EU_HOST})...`
+        `Cloudflare Tunnel (${TUNNEL_HOST}) is UNHEALTHY. Probing US VPS (${VPS_US_HOST})...`
       )
 
-      // 2. Probe Tier 2: EU VPS (Hetzner)
-      const euProbe = await probeHost(VPS_EU_HOST)
-      allProbeLogs.push(...euProbe.attempts)
+      // 2. Probe Tier 2: US VPS (OVHcloud)
+      const usProbe = await probeHost(VPS_US_HOST)
+      allProbeLogs.push(...usProbe.attempts)
 
-      if (euProbe.isUp) {
-        targetContent = PROXY_EU_CNAME
-        targetTier = "EU Region (Hetzner VPS / Proxy)"
+      if (usProbe.isUp) {
+        targetContent = PROXY_US_CNAME
+        targetTier =
+          "US Region (OVHcloud VPS / Proxy) — degraded, higher latency"
         isProxied = false
+        degraded = true
         console.log(
-          `EU VPS (${VPS_EU_HOST}) is healthy. Routing to ${PROXY_EU_CNAME}.`
+          `US VPS (${VPS_US_HOST}) is healthy. Routing to ${PROXY_US_CNAME}.`
         )
       } else {
-        // 3. Tier 3 Fallback: Cloudflare Tunnel
-        targetContent = TUNNEL_CNAME
-        targetTier = "Fallback (Cloudflare Tunnel)"
-        isProxied = true
-        console.error(
-          `Both US and EU VPS are UNHEALTHY! Falling back to Cloudflare Tunnel (${TUNNEL_CNAME}).`
+        console.warn(
+          `US VPS (${VPS_US_HOST}) is UNHEALTHY. Probing EU VPS (${VPS_EU_HOST})...`
         )
+
+        // 3. Probe Tier 3: EU VPS (Hetzner)
+        const euProbe = await probeHost(VPS_EU_HOST)
+        allProbeLogs.push(...euProbe.attempts)
+
+        if (euProbe.isUp) {
+          targetContent = PROXY_EU_CNAME
+          targetTier =
+            "EU Region (Hetzner VPS / Proxy) — degraded, higher latency"
+          isProxied = false
+          degraded = true
+          console.log(
+            `EU VPS (${VPS_EU_HOST}) is healthy. Routing to ${PROXY_EU_CNAME}.`
+          )
+        } else {
+          console.error(
+            `Tunnel, US VPS, and EU VPS are ALL unhealthy! Leaving ${RECORD_NAME} unchanged and alerting.`
+          )
+        }
       }
     }
 
@@ -242,6 +267,27 @@ export default {
       console.log(`Current DNS record content: ${currentContent}`)
     } catch (err) {
       console.error(`Error querying DNS record:`, err)
+      return
+    }
+
+    if (targetContent === null) {
+      // All tiers unhealthy: nothing sane to switch to, just alert.
+      const now = new Date()
+      ctx.waitUntil(
+        sendEmailViaSMTP(
+          env,
+          fromEmail,
+          toEmail,
+          `[CRITICAL] ${RECORD_NAME} has no healthy ingress tier - ${now.toISOString()}`,
+          [
+            `All three ingress tiers (Cloudflare Tunnel, US VPS, EU VPS) failed their health checks.`,
+            `${RECORD_NAME} was left pointing at its last-known-good target: ${currentContent}.`,
+            ``,
+            `=== Probe Attempts ===`,
+            ...allProbeLogs,
+          ].join("\r\n")
+        )
+      )
       return
     }
 
@@ -280,7 +326,6 @@ export default {
               `DNS record successfully updated to point to ${targetContent} (proxied: ${isProxied}, Tier: ${targetTier})`
             )
 
-            // Format Subject line with date and hour
             const now = new Date()
             const yyyy = now.getUTCFullYear()
             const mm = String(now.getUTCMonth() + 1).padStart(2, "0")
@@ -288,9 +333,10 @@ export default {
             const hh = String(now.getUTCHours()).padStart(2, "0")
             const dateStr = `${yyyy}-${mm}-${dd} ${hh}:00 UTC`
 
-            const subject = `[Failover] Ingress DNS Switched to ${targetTier} - ${dateStr}`
+            const severity = degraded ? "[Degraded Failover]" : "[Failover]"
+            const subject = `${severity} ${RECORD_NAME} switched to ${targetTier} - ${dateStr}`
             const body = [
-              `Failover monitor detected that the ingress DNS record ${RECORD_NAME} was pointing to ${currentContent}, but has been updated to ${targetContent} (${targetTier}).`,
+              `Fast-failover monitor detected that ${RECORD_NAME} was pointing to ${currentContent}, but has been updated to ${targetContent} (${targetTier}).`,
               ``,
               `Action: DNS record updated to a CNAME pointing to ${targetContent} (proxied: ${isProxied}).`,
               ``,
@@ -314,7 +360,7 @@ export default {
       }
     } else {
       console.log(
-        `No action required. Ingress target is already aligned with active healthy node (${currentContent} - ${targetTier}).`
+        `No action required. ${RECORD_NAME} is already aligned with active healthy tier (${currentContent} - ${targetTier}).`
       )
     }
   },

--- a/cluster/apps/networking/ingress-vps/failover-fast/fast-failover-monitor.js
+++ b/cluster/apps/networking/ingress-vps/failover-fast/fast-failover-monitor.js
@@ -174,8 +174,6 @@ export default {
     const TUNNEL_CNAME = env.TUNNEL_CNAME
     const PROXY_ROUND_ROBIN_CNAME =
       env.PROXY_ROUND_ROBIN_CNAME || `proxy.${SECRET_DOMAIN}`
-    const PROXY_US_CNAME = env.PROXY_US_CNAME || `proxy-us.${SECRET_DOMAIN}`
-    const PROXY_EU_CNAME = env.PROXY_EU_CNAME || `proxy-eu.${SECRET_DOMAIN}`
     const ZONE_ID = env.CLOUDFLARE_ZONE_ID
     const RECORD_ID = env.CLOUDFLARE_RECORD_ID
     const API_TOKEN = env.CLOUDFLARE_API_TOKEN
@@ -221,19 +219,19 @@ export default {
           `Both VPS regions are healthy. Routing to ${PROXY_ROUND_ROBIN_CNAME}.`
         )
       } else if (usProbe.isUp) {
-        targetContent = PROXY_US_CNAME
+        targetContent = VPS_US_HOST
         targetTier =
           "US Region (OVHcloud VPS / Proxy) — degraded, higher latency"
         isProxied = false
         degraded = true
-        console.log(`Only US VPS is healthy. Routing to ${PROXY_US_CNAME}.`)
+        console.log(`Only US VPS is healthy. Routing to ${VPS_US_HOST}.`)
       } else if (euProbe.isUp) {
-        targetContent = PROXY_EU_CNAME
+        targetContent = VPS_EU_HOST
         targetTier =
           "EU Region (Hetzner VPS / Proxy) — degraded, higher latency"
         isProxied = false
         degraded = true
-        console.log(`Only EU VPS is healthy. Routing to ${PROXY_EU_CNAME}.`)
+        console.log(`Only EU VPS is healthy. Routing to ${VPS_EU_HOST}.`)
       } else {
         console.error(
           `Tunnel, US VPS, and EU VPS are ALL unhealthy! Leaving ${RECORD_NAME} unchanged and alerting.`

--- a/cluster/apps/networking/ingress-vps/failover-fast/main.tf
+++ b/cluster/apps/networking/ingress-vps/failover-fast/main.tf
@@ -90,6 +90,11 @@ resource "cloudflare_workers_script" "fast_failover_monitor" {
       text = "vps-eu.${var.secret_domain}"
     },
     {
+      name = "PROXY_ROUND_ROBIN_CNAME"
+      type = "plain_text"
+      text = "proxy.${var.secret_domain}"
+    },
+    {
       name = "PROXY_US_CNAME"
       type = "plain_text"
       text = "proxy-us.${var.secret_domain}"

--- a/cluster/apps/networking/ingress-vps/failover-fast/main.tf
+++ b/cluster/apps/networking/ingress-vps/failover-fast/main.tf
@@ -41,14 +41,16 @@ data "cloudflare_zones" "domain_zones" {
   name = var.secret_domain
 }
 
-# 2. Ingress CNAME (pointing to a regional VPS proxy or the failover tunnel) — used only by
-#    the apps carved out of the CF-primary path (see cluster/apps/networking/ingress-vps/failover-fast)
-resource "cloudflare_dns_record" "ingress" {
+# 2. Fast-path CNAME: Cloudflare Tunnel by default, VPS as a degraded fallback.
+#    Every externally-exposed app is on this record unless it explicitly overrides
+#    external-dns.kubernetes.io/target back to ingress.${secret_domain} (see the
+#    external-gateway default in cluster/apps/networking/traefik/external/gateway.yaml).
+resource "cloudflare_dns_record" "fast" {
   zone_id = data.cloudflare_zones.domain_zones.result[0].id
-  name    = "ingress.${var.secret_domain}"
-  content = "proxy-us.${var.secret_domain}"
+  name    = "fast.${var.secret_domain}"
+  content = var.cloudflare_tunnel_cname
   type    = "CNAME"
-  proxied = false
+  proxied = true
   ttl     = 1
 
   lifecycle {
@@ -60,13 +62,23 @@ resource "cloudflare_dns_record" "ingress" {
 }
 
 # 3. Deploy the Cloudflare Worker Script & Bindings Declaratively
-resource "cloudflare_workers_script" "failover_monitor" {
+resource "cloudflare_workers_script" "fast_failover_monitor" {
   account_id  = data.cloudflare_zones.domain_zones.result[0].account.id
-  script_name = "ingress-tunnel-failover-monitor"
-  content     = file("${path.module}/failover-monitor.js")
-  main_module = "failover-monitor.js"
+  script_name = "fast-ingress-failover-monitor"
+  content     = file("${path.module}/fast-failover-monitor.js")
+  main_module = "fast-failover-monitor.js"
 
   bindings = [
+    {
+      name = "TUNNEL_HOST"
+      type = "plain_text"
+      text = "external.${var.secret_domain}"
+    },
+    {
+      name = "TUNNEL_CNAME"
+      type = "plain_text"
+      text = var.cloudflare_tunnel_cname
+    },
     {
       name = "VPS_US_HOST"
       type = "plain_text"
@@ -88,11 +100,6 @@ resource "cloudflare_workers_script" "failover_monitor" {
       text = "proxy-eu.${var.secret_domain}"
     },
     {
-      name = "TUNNEL_CNAME"
-      type = "plain_text"
-      text = var.cloudflare_tunnel_cname
-    },
-    {
       name = "CLOUDFLARE_ZONE_ID"
       type = "plain_text"
       text = data.cloudflare_zones.domain_zones.result[0].id
@@ -100,12 +107,12 @@ resource "cloudflare_workers_script" "failover_monitor" {
     {
       name = "CLOUDFLARE_RECORD_ID"
       type = "plain_text"
-      text = cloudflare_dns_record.ingress.id
+      text = cloudflare_dns_record.fast.id
     },
     {
       name = "RECORD_NAME"
       type = "plain_text"
-      text = "ingress.${var.secret_domain}"
+      text = "fast.${var.secret_domain}"
     },
     {
       name = "SMTP_SERVER"
@@ -131,9 +138,9 @@ resource "cloudflare_workers_script" "failover_monitor" {
 }
 
 # 4. Create the Cron Trigger for the Worker (runs every minute)
-resource "cloudflare_workers_cron_trigger" "failover_cron" {
+resource "cloudflare_workers_cron_trigger" "fast_failover_cron" {
   account_id  = data.cloudflare_zones.domain_zones.result[0].account.id
-  script_name = cloudflare_workers_script.failover_monitor.script_name
+  script_name = cloudflare_workers_script.fast_failover_monitor.script_name
   schedules = [
     {
       cron = "* * * * *"

--- a/cluster/apps/networking/ingress-vps/failover-fast/main.tf
+++ b/cluster/apps/networking/ingress-vps/failover-fast/main.tf
@@ -95,16 +95,6 @@ resource "cloudflare_workers_script" "fast_failover_monitor" {
       text = "proxy.${var.secret_domain}"
     },
     {
-      name = "PROXY_US_CNAME"
-      type = "plain_text"
-      text = "proxy-us.${var.secret_domain}"
-    },
-    {
-      name = "PROXY_EU_CNAME"
-      type = "plain_text"
-      text = "proxy-eu.${var.secret_domain}"
-    },
-    {
       name = "CLOUDFLARE_ZONE_ID"
       type = "plain_text"
       text = data.cloudflare_zones.domain_zones.result[0].id

--- a/cluster/apps/networking/ingress-vps/failover/failover-monitor.js
+++ b/cluster/apps/networking/ingress-vps/failover/failover-monitor.js
@@ -166,8 +166,6 @@ export default {
     const SECRET_DOMAIN = RECORD_NAME.replace(/^ingress\./, "")
     const PROXY_ROUND_ROBIN_CNAME =
       env.PROXY_ROUND_ROBIN_CNAME || `proxy.${SECRET_DOMAIN}`
-    const PROXY_US_CNAME = env.PROXY_US_CNAME || `proxy-us.${SECRET_DOMAIN}`
-    const PROXY_EU_CNAME = env.PROXY_EU_CNAME || `proxy-eu.${SECRET_DOMAIN}`
     const TUNNEL_CNAME = env.TUNNEL_CNAME || `external.${SECRET_DOMAIN}`
     const ZONE_ID = env.CLOUDFLARE_ZONE_ID
     const RECORD_ID = env.CLOUDFLARE_RECORD_ID
@@ -198,15 +196,15 @@ export default {
         `Both US and EU VPS are healthy. Routing to ${PROXY_ROUND_ROBIN_CNAME}.`
       )
     } else if (usProbe.isUp) {
-      targetContent = PROXY_US_CNAME
+      targetContent = VPS_US_HOST
       targetTier = "US Region (OVHcloud VPS / Proxy)"
       isProxied = false
-      console.log(`Only US VPS is healthy. Routing to ${PROXY_US_CNAME}.`)
+      console.log(`Only US VPS is healthy. Routing to ${VPS_US_HOST}.`)
     } else if (euProbe.isUp) {
-      targetContent = PROXY_EU_CNAME
+      targetContent = VPS_EU_HOST
       targetTier = "EU Region (Hetzner VPS / Proxy)"
       isProxied = false
-      console.log(`Only EU VPS is healthy. Routing to ${PROXY_EU_CNAME}.`)
+      console.log(`Only EU VPS is healthy. Routing to ${VPS_EU_HOST}.`)
     } else {
       // Tier 3 Fallback: Cloudflare Tunnel
       targetContent = TUNNEL_CNAME

--- a/cluster/apps/networking/ingress-vps/failover/failover-monitor.js
+++ b/cluster/apps/networking/ingress-vps/failover/failover-monitor.js
@@ -164,6 +164,8 @@ export default {
     const VPS_EU_HOST = env.VPS_EU_HOST
     const RECORD_NAME = env.RECORD_NAME
     const SECRET_DOMAIN = RECORD_NAME.replace(/^ingress\./, "")
+    const PROXY_ROUND_ROBIN_CNAME =
+      env.PROXY_ROUND_ROBIN_CNAME || `proxy.${SECRET_DOMAIN}`
     const PROXY_US_CNAME = env.PROXY_US_CNAME || `proxy-us.${SECRET_DOMAIN}`
     const PROXY_EU_CNAME = env.PROXY_EU_CNAME || `proxy-eu.${SECRET_DOMAIN}`
     const TUNNEL_CNAME = env.TUNNEL_CNAME || `external.${SECRET_DOMAIN}`
@@ -179,42 +181,40 @@ export default {
     let targetTier = null
     let isProxied = false
 
-    // 1. Probe Tier 1: US VPS (OVHcloud)
+    // Probe both regions (not short-circuited) so we can tell "both healthy" apart
+    // from "only one healthy" — those need different targets.
     const usProbe = await probeHost(VPS_US_HOST)
     allProbeLogs.push(...usProbe.attempts)
+    const euProbe = await probeHost(VPS_EU_HOST)
+    allProbeLogs.push(...euProbe.attempts)
 
-    if (usProbe.isUp) {
+    if (usProbe.isUp && euProbe.isUp) {
+      // Both regions healthy: use the shared round-robin record so clients can race
+      // both IPs and land on whichever one responds first for them.
+      targetContent = PROXY_ROUND_ROBIN_CNAME
+      targetTier = "US + EU (round-robin Proxy)"
+      isProxied = false
+      console.log(
+        `Both US and EU VPS are healthy. Routing to ${PROXY_ROUND_ROBIN_CNAME}.`
+      )
+    } else if (usProbe.isUp) {
       targetContent = PROXY_US_CNAME
       targetTier = "US Region (OVHcloud VPS / Proxy)"
       isProxied = false
-      console.log(
-        `US VPS (${VPS_US_HOST}) is healthy. Routing to ${PROXY_US_CNAME}.`
-      )
+      console.log(`Only US VPS is healthy. Routing to ${PROXY_US_CNAME}.`)
+    } else if (euProbe.isUp) {
+      targetContent = PROXY_EU_CNAME
+      targetTier = "EU Region (Hetzner VPS / Proxy)"
+      isProxied = false
+      console.log(`Only EU VPS is healthy. Routing to ${PROXY_EU_CNAME}.`)
     } else {
-      console.warn(
-        `US VPS (${VPS_US_HOST}) is UNHEALTHY. Probing EU VPS (${VPS_EU_HOST})...`
+      // Tier 3 Fallback: Cloudflare Tunnel
+      targetContent = TUNNEL_CNAME
+      targetTier = "Fallback (Cloudflare Tunnel)"
+      isProxied = true
+      console.error(
+        `Both US and EU VPS are UNHEALTHY! Falling back to Cloudflare Tunnel (${TUNNEL_CNAME}).`
       )
-
-      // 2. Probe Tier 2: EU VPS (Hetzner)
-      const euProbe = await probeHost(VPS_EU_HOST)
-      allProbeLogs.push(...euProbe.attempts)
-
-      if (euProbe.isUp) {
-        targetContent = PROXY_EU_CNAME
-        targetTier = "EU Region (Hetzner VPS / Proxy)"
-        isProxied = false
-        console.log(
-          `EU VPS (${VPS_EU_HOST}) is healthy. Routing to ${PROXY_EU_CNAME}.`
-        )
-      } else {
-        // 3. Tier 3 Fallback: Cloudflare Tunnel
-        targetContent = TUNNEL_CNAME
-        targetTier = "Fallback (Cloudflare Tunnel)"
-        isProxied = true
-        console.error(
-          `Both US and EU VPS are UNHEALTHY! Falling back to Cloudflare Tunnel (${TUNNEL_CNAME}).`
-        )
-      }
     }
 
     // 4. Query current DNS record

--- a/cluster/apps/networking/ingress-vps/failover/main.tf
+++ b/cluster/apps/networking/ingress-vps/failover/main.tf
@@ -41,12 +41,13 @@ data "cloudflare_zones" "domain_zones" {
   name = var.secret_domain
 }
 
-# 2. Ingress CNAME (pointing to a regional VPS proxy or the failover tunnel) — used only by
-#    the apps carved out of the CF-primary path (see cluster/apps/networking/ingress-vps/failover-fast)
+# 2. Ingress CNAME (pointing to the round-robin proxy, a single healthy region, or the
+#    failover tunnel) — used only by the apps carved out of the CF-primary path
+#    (see cluster/apps/networking/ingress-vps/failover-fast)
 resource "cloudflare_dns_record" "ingress" {
   zone_id = data.cloudflare_zones.domain_zones.result[0].id
   name    = "ingress.${var.secret_domain}"
-  content = "proxy-us.${var.secret_domain}"
+  content = "proxy.${var.secret_domain}"
   type    = "CNAME"
   proxied = false
   ttl     = 1
@@ -76,6 +77,11 @@ resource "cloudflare_workers_script" "failover_monitor" {
       name = "VPS_EU_HOST"
       type = "plain_text"
       text = "vps-eu.${var.secret_domain}"
+    },
+    {
+      name = "PROXY_ROUND_ROBIN_CNAME"
+      type = "plain_text"
+      text = "proxy.${var.secret_domain}"
     },
     {
       name = "PROXY_US_CNAME"

--- a/cluster/apps/networking/ingress-vps/failover/main.tf
+++ b/cluster/apps/networking/ingress-vps/failover/main.tf
@@ -84,16 +84,6 @@ resource "cloudflare_workers_script" "failover_monitor" {
       text = "proxy.${var.secret_domain}"
     },
     {
-      name = "PROXY_US_CNAME"
-      type = "plain_text"
-      text = "proxy-us.${var.secret_domain}"
-    },
-    {
-      name = "PROXY_EU_CNAME"
-      type = "plain_text"
-      text = "proxy-eu.${var.secret_domain}"
-    },
-    {
       name = "TUNNEL_CNAME"
       type = "plain_text"
       text = var.cloudflare_tunnel_cname

--- a/cluster/apps/networking/ingress-vps/us/.terraform.lock.hcl
+++ b/cluster/apps/networking/ingress-vps/us/.terraform.lock.hcl
@@ -99,6 +99,79 @@ provider "registry.opentofu.org/hashicorp/kubernetes" {
   ]
 }
 
+provider "registry.opentofu.org/hashicorp/null" {
+  version = "3.3.1"
+  hashes = [
+    "h1:2wld81FnmHW0WVgy081sIfokCr2+NuatS8yjeLEet7Y=",
+    "h1:AClQjJ6X22V4qcRgcYSxiXCMmp2pz0G8WVQC7wAx66o=",
+    "h1:AY3XQbuviNd2X5VhHYEbhNta1m/CG3JD2BKFKhCt1Y4=",
+    "h1:CUOZUd7H11lsU+4tISlnYIiP5BqnX8IDwFCVqfLJyAg=",
+    "h1:JIfV0nA/pLWnIFGscvTfuavQCn2NeHxJBeb6UUg/joA=",
+    "h1:RejAh+nyCwqDGExGln2Kb4Ro5LyHak0eJe0P9g8CHPc=",
+    "h1:SHOuTZjYymsmy4asuRq6NC3yW+zdVZOOt4f5nrb+EPM=",
+    "h1:WwPat/gT4gO8GvvKNdSkkXWVD65JppLJfqKOt9HhOqQ=",
+    "h1:Z3hXVLrOyaRiiLmmL5UCOdcRMguwjN1x5TYNdmBDgls=",
+    "h1:dd78Ad5HdfPzPts7A9qIxfitXhAriV/qza38fr2ukjk=",
+    "h1:dyVb++KwDdybzLTE6bf7GZiVQ31iWsgKPWmhTQ8G42k=",
+    "h1:gD8ZH6WWe+5gg5+y8SpLWGPUDzSxcQ3HKP8IDM/wW3I=",
+    "h1:juXCww0zRQKFTDZoKqYR0+Sn1lu99oeL6pr0Jh6LWx0=",
+    "h1:kFAySmtsshyNV7IhIrEdASzVcvwy68eeZCVC66P7yNk=",
+    "h1:nS5azDopRisB2NInwDx3Hrfg2FdVt8Gw0gTQzC0rd70=",
+    "zh:164eb061d84e01759f391265865fb31828083d0a06b25f7af7e094cbdb18c799",
+    "zh:1bb9b669a82b52c0cba2860c71e9ee6699ef302f28cb8ed06f572d39bc6c7c4f",
+    "zh:1ea9b31a8f29302122c1e8d673693f3ac270336dae560af803cd1117265a469a",
+    "zh:238bd463cb0154fb935dc331da40c0a9cbe5db9cee615ae5f35ccad5eed7dc41",
+    "zh:30ef2b7384cf7e20f33fe75754b54cf669d59816f3ad4fc73bfb2b26fb6735e9",
+    "zh:35b5cded16e4b57c207d03ee0979b14baf486fa520e6edb7a2eecf18f1b85471",
+    "zh:3dc840d13a50cd215c7540573f27e2b61f739ba90aee5b7c3846079aa0ab5534",
+    "zh:3f9309a18db608f975d5691fcb47a6e14d77199156a52e9c39dcafe3737f2b07",
+    "zh:44263a219f7dbd1848b545d080110b4f7d0495e77b71cd3c7a0b5ec52a09accb",
+    "zh:4dec54aa5f445eeea035bbd4839bcded5e47ecd07cba0e70c5a09e9272cb592f",
+    "zh:5e8fb319d7c6d6c4566a18b9d0c91580b4901a96acd7fdc476bfc79f074368e2",
+    "zh:b0e8b6d41834b57fcfbb5ca00da52ccb757e1a95b6a2d546c0dae8bfbeca1cdf",
+    "zh:bbde4c3a1dcc1718027a61a4cdf661619d17af1b58df1038fe27bcf43c3dc29b",
+    "zh:c4140fff9f692baf29236557f706f9515f93229413438527d764023a82301da3",
+    "zh:f8e9d83184e4bbeb97c6f0d569833007c48ba5a7ff334def201df4991d03a962",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/tls" {
+  version     = "4.4.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:37OPfmlziRrBgEz2oZEYOSvANEjFtDZK8S7CXchV6hg=",
+    "h1:8KHKh+WnimOwrte+RK3fDNX3wM14fUbKL6alOHhS8G0=",
+    "h1:B7yGz4mpkSlsqxC7+4ZhWft49zF42wphoGYeXM3vMIo=",
+    "h1:Eb+WGv4GM+Wad6XQPBY4yKIzledal6lhQYaw5NXMNvk=",
+    "h1:QQHdl1Dd5WiZx3vZhvHo8FYyte49JODt0PaFoJnGDLk=",
+    "h1:Ts5hrfNaAKPw6gX0SLHJrOFXDwIo/eW20ePuU7mL5e8=",
+    "h1:ZHcWyrqBZK/wh4wSPScMnNtf0k9BGe0TIE7GQ28oJK0=",
+    "h1:a6wTdpC0rNTeQ5wQSzSggnBqYbElNcq6ZjZfvwT5ivE=",
+    "h1:hdZOgvtirMaflk1GOVMUxYw2g0tRDbgELbjjxbDm6dY=",
+    "h1:hmiQdLrPJpUB2bzKAXZnQ5dcvwRA9MqB0mWpdlhkBIw=",
+    "h1:i9X1kPBpE8gP6hDu8V0bfjDKdaIAdnwWGePJARunXlM=",
+    "h1:iZBNaQrjv5pc1ZK83nDHQluFx5KjyxagzWtr5ggnSH8=",
+    "h1:q/ZAqq4V1gxd72nVs1/URKx2XIPtGrq3YgE/Jtp5kl4=",
+    "h1:q7lks7YmQ4pi5TQ0PR6BLGxXnjBMv4NvjcvvtuelHI0=",
+    "h1:q8l99jPnlD8ys9jsQQknLCaYrA1NTNwirzFfEOrjxFI=",
+    "zh:0f715faf86fc318c31ef0bbe591c148d359e0aaabd5410435503dd6f71f2ea6c",
+    "zh:15e748a856d4f6e751c98125f08599a1be997296ce40a7fc19109c99d95a8639",
+    "zh:60c917163488bddc83efdc7a87b2a6b3dc589c3aedab6ff5da3c719aaf26fb61",
+    "zh:6a2ea5fe39fb47a3eb112e85a513a229fc4dc69cac742d656dd36ce986ffa8bf",
+    "zh:6c5c0d242a59f127f4c833dab41cc827a98e9a5081e9efed2de7a33355c8420f",
+    "zh:82da7ec5151b2e7fefa2279180fa408af7f35cdb3ce41d5b918bca60c74bb19d",
+    "zh:8e4821e874d9ddf6636de6b1f0cd0319fb759d707ff8a2a1edf692ede77bd10f",
+    "zh:96fb4be355b175410edc83399dbc9439c351efb8542a70c9314aa2c6ee6800f2",
+    "zh:9c1f608a4743aaa3567859ac3c00c13173022fe571aa06ecb9d32239a8fc891a",
+    "zh:a36197d236af47e5d16143384559879b96aa47f2d6c68a805dd64eeaab2901c4",
+    "zh:d40089905435cff7a508d783bf66b50c54d8619c1f1dad2bedf4822ab22826d7",
+    "zh:e344c7a0ab62b1d21340258cbcb4bbc3fe41281347d7aff0b8900e5944427183",
+    "zh:f1263e791fee7229bf16114f875ec7ff4db8e6727db914715d903fc377168522",
+    "zh:f3bfab9d65bfd3a553e584f40f94f8827230a6c12a11e813351c6365f58be96e",
+    "zh:fcf6e1d3a86a3f0c8aabbdededb5ad4f494236741677aedff48023468e18b0f8",
+  ]
+}
+
 provider "registry.opentofu.org/ovh/ovh" {
   version     = "2.19.0"
   constraints = "2.19.0"

--- a/cluster/apps/networking/ingress-vps/us/main.tf
+++ b/cluster/apps/networking/ingress-vps/us/main.tf
@@ -86,6 +86,14 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 3.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
   }
 }
 
@@ -118,6 +126,22 @@ data "cloudflare_zones" "domain_zones" {
   name = var.secret_domain
 }
 
+# Read the cluster's cert-manager-issued wildcard cert so TF can push it to the
+# VPS whenever it renews, without that being part of the (replace-triggering)
+# instance user_data.
+data "kubernetes_secret_v1" "wildcard_cert" {
+  metadata {
+    name      = "wildcard-${replace(var.secret_domain, ".", "-")}-tls"
+    namespace = "networking"
+  }
+}
+
+# Dedicated automation keypair for TF-driven post-boot provisioning (cert/whitelist
+# pushes). Kept separate from var.ssh_public_key, which remains the human/break-glass key.
+resource "tls_private_key" "tf_admin" {
+  algorithm = "ED25519"
+}
+
 # OVH Public Cloud US Ingress VPS
 data "ovh_cloud_project_images" "debian" {
   service_name = var.ovh_service_name
@@ -145,12 +169,13 @@ resource "terraform_data" "cloud_init_us" {
       NETBIRD_SELFHOSTED_MGMT_URL  = "https://nb.${var.secret_domain}"
       NETBIRD_RELAY_AUTH_SECRET    = var.netbird_relay_auth_secret
       SECRET_DOMAIN                = var.secret_domain
-      HOME_IP                      = local.home_ip
       PROBE_HOSTNAME               = "vps-us.${var.secret_domain}"
       WG_PRIVATE_KEY               = var.peer_us_private_key
       WG_PEER_PUBLIC_KEY           = var.wg_public_key
       WG_ADDRESS                   = "10.13.13.10/32"
       NB_ADDR                      = "10.0.10.11"
+      SSH_PUBLIC_KEY               = var.ssh_public_key
+      TF_ADMIN_SSH_PUBLIC_KEY      = tls_private_key.tf_admin.public_key_openssh
     })
   }
 }
@@ -207,10 +232,12 @@ resource "cloudflare_dns_record" "vps_us" {
   ttl     = 1
 }
 
-# Proxy IPv4 A record for US VPS
+# Proxy IPv4 A record for US VPS (region-specific: proxy.${domain} used to be
+# shared with the EU stack, which meant whichever region applied last silently
+# stole the record regardless of which one was actually healthy)
 resource "cloudflare_dns_record" "proxy_us" {
   zone_id = data.cloudflare_zones.domain_zones.result[0].id
-  name    = "proxy.${var.secret_domain}"
+  name    = "proxy-us.${var.secret_domain}"
   content = local.ovh_us_ipv4
   type    = "A"
   proxied = false
@@ -253,6 +280,96 @@ resource "kubernetes_secret_v1" "vps_us_output_flux" {
 
   data = {
     VPS_US_PUBLIC_IP = local.ovh_us_ipv4
+  }
+
+  depends_on = [
+    data.http.vps_us_healthcheck
+  ]
+}
+
+# Push the current cert-manager wildcard cert to the VPS and reload Traefik.
+# Triggered only by cert content, so a renewal never touches user_data / replaces the instance.
+resource "null_resource" "cert_sync" {
+  triggers = {
+    cert_hash = sha256(join("", [
+      data.kubernetes_secret_v1.wildcard_cert.data["tls.crt"],
+      data.kubernetes_secret_v1.wildcard_cert.data["tls.key"],
+    ]))
+  }
+
+  connection {
+    type        = "ssh"
+    host        = local.ovh_us_ipv4
+    user        = "debian"
+    private_key = tls_private_key.tf_admin.private_key_openssh
+    timeout     = "2m"
+  }
+
+  provisioner "file" {
+    content     = data.kubernetes_secret_v1.wildcard_cert.data["tls.crt"]
+    destination = "/tmp/tls.crt"
+  }
+
+  provisioner "file" {
+    content     = data.kubernetes_secret_v1.wildcard_cert.data["tls.key"]
+    destination = "/tmp/tls.key"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo install -o root -g root -m 0644 /tmp/tls.crt /etc/traefik/certs/tls.crt",
+      "sudo install -o root -g root -m 0600 /tmp/tls.key /etc/traefik/certs/tls.key",
+      "rm -f /tmp/tls.crt /tmp/tls.key",
+      "sudo systemctl restart traefik",
+    ]
+  }
+
+  depends_on = [
+    data.http.vps_us_healthcheck
+  ]
+}
+
+# Push the current home egress IP into CrowdSec's whitelist and reload it in place.
+# Triggered only by home_ip, so a residential IP change never touches user_data / replaces the instance.
+resource "null_resource" "home_ip_whitelist_sync" {
+  triggers = {
+    home_ip = local.home_ip
+  }
+
+  connection {
+    type        = "ssh"
+    host        = local.ovh_us_ipv4
+    user        = "debian"
+    private_key = tls_private_key.tf_admin.private_key_openssh
+    timeout     = "2m"
+  }
+
+  provisioner "file" {
+    content     = <<-EOF
+      name: local/whitelist
+      description: "Whitelist trusted IPs and internal networks"
+      filter: "1 == 1"
+      whitelist:
+        reason: "Whitelisted home IP and internal overlay networks"
+        ip:
+          - "${local.home_ip}"
+          - "127.0.0.1"
+          - "::1"
+        cidr:
+          - "100.64.0.0/10"
+          - "10.0.0.0/8"
+          - "172.16.0.0/12"
+          - "192.168.0.0/16"
+    EOF
+    destination = "/tmp/00-whitelist.yaml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo install -o root -g root -m 0644 /tmp/00-whitelist.yaml /etc/crowdsec/parsers/s02-enrich/00-whitelist.yaml",
+      "rm -f /tmp/00-whitelist.yaml",
+      "sudo docker exec crowdsec cscli reload",
+    ]
   }
 
   depends_on = [

--- a/cluster/apps/networking/ingress-vps/us/main.tf
+++ b/cluster/apps/networking/ingress-vps/us/main.tf
@@ -246,17 +246,8 @@ resource "cloudflare_dns_record" "proxy_us" {
   ttl     = 1
 }
 
-# Region-specific record (not client-facing): lets the failover workers target this
-# region alone when the other is unhealthy, which the shared round-robin name above
-# can't express.
-resource "cloudflare_dns_record" "proxy_us_only" {
-  zone_id = data.cloudflare_zones.domain_zones.result[0].id
-  name    = "proxy-us.${var.secret_domain}"
-  content = local.ovh_us_ipv4
-  type    = "A"
-  proxied = false
-  ttl     = 1
-}
+# Note: no separate region-specific "proxy-us" record — vps-us.${domain} below already
+# is one (single IP, same content), so the failover workers just target that directly.
 
 # Output US VPS public IP
 output "VPS_US_PUBLIC_IP" {

--- a/cluster/apps/networking/ingress-vps/us/main.tf
+++ b/cluster/apps/networking/ingress-vps/us/main.tf
@@ -232,10 +232,24 @@ resource "cloudflare_dns_record" "vps_us" {
   ttl     = 1
 }
 
-# Proxy IPv4 A record for US VPS (region-specific: proxy.${domain} used to be
-# shared with the EU stack, which meant whichever region applied last silently
-# stole the record regardless of which one was actually healthy)
+# Proxy IPv4 A record for US VPS. Shared name with the EU stack's own record below
+# (each region's own Terraform state independently manages its own record; Cloudflare
+# adds both under the same name rather than one overwriting the other) — this gives a
+# real round-robin RRset so clients can race both regions and land on whichever
+# responds first, when both happen to be healthy.
 resource "cloudflare_dns_record" "proxy_us" {
+  zone_id = data.cloudflare_zones.domain_zones.result[0].id
+  name    = "proxy.${var.secret_domain}"
+  content = local.ovh_us_ipv4
+  type    = "A"
+  proxied = false
+  ttl     = 1
+}
+
+# Region-specific record (not client-facing): lets the failover workers target this
+# region alone when the other is unhealthy, which the shared round-robin name above
+# can't express.
+resource "cloudflare_dns_record" "proxy_us_only" {
   zone_id = data.cloudflare_zones.domain_zones.result[0].id
   name    = "proxy-us.${var.secret_domain}"
   content = local.ovh_us_ipv4

--- a/cluster/apps/networking/ingress-vps/us/vps-cloud-init.yaml
+++ b/cluster/apps/networking/ingress-vps/us/vps-cloud-init.yaml
@@ -1,4 +1,8 @@
 #cloud-config
+ssh_authorized_keys:
+  - ${SSH_PUBLIC_KEY}
+  - ${TF_ADMIN_SSH_PUBLIC_KEY}
+
 write_files:
   # 1. Write Traefik Edge Ingress Proxy Static Configuration
   - path: /etc/traefik/traefik.yaml
@@ -9,12 +13,18 @@ write_files:
           address: ":80"
         websecure:
           address: ":443"
+          transport:
+            respondingTimeouts:
+              readTimeout: 3600s
+              idleTimeout: 3600s
+              writeTimeout: 3600s
         metrics:
           address: ":8082"
 
       providers:
         file:
           filename: "/etc/traefik/dynamic.yaml"
+          watch: true
 
       metrics:
         prometheus:
@@ -25,7 +35,11 @@ write_files:
 
       accessLog: {}
 
-  # 2. Write Traefik Edge Ingress Proxy Dynamic Configuration (SNI TLS Passthrough to K8s)
+  # 2. Write Traefik Edge Ingress Proxy Dynamic Configuration (TLS terminated at the
+  #    edge, forwarded to the cluster's own websecure entrypoint over the wg0 tunnel;
+  #    wg0 already encrypts that leg, and terminating here lets Traefik pool/reuse the
+  #    backend connection instead of paying a full TLS handshake over the tunnel per
+  #    client request, and gives CrowdSec real HTTP visibility instead of opaque TCP.
   - path: /etc/traefik/dynamic.yaml
     permissions: "0644"
     content: |
@@ -36,28 +50,33 @@ write_files:
               - web
             rule: "HostRegexp(`{host:.+}`)"
             service: k8s-http
+          websecure-catchall:
+            entryPoints:
+              - websecure
+            rule: "HostRegexp(`{host:.+}`)"
+            service: k8s-https
+            tls: {}
         services:
           k8s-http:
             loadBalancer:
               servers:
                 - url: "http://10.0.10.20:80"
-
-      tcp:
-        routers:
-          sni-passthrough:
-            entryPoints:
-              - websecure
-            rule: "HostSNI(`*`)"
-            service: k8s-traefik
-            tls:
-              passthrough: true
-        services:
-          k8s-traefik:
+          k8s-https:
             loadBalancer:
-              proxyProtocol:
-                version: 2
               servers:
-                - address: "10.0.10.20:443"
+                - url: "https://10.0.10.20:443"
+              serversTransport: k8s-internal
+        serversTransports:
+          k8s-internal:
+            # The cluster's own websecure listener already terminates the same
+            # wildcard cert; skip verification because the transport itself (WireGuard)
+            # is what actually authenticates this leg, not the TLS handshake.
+            insecureSkipVerify: true
+
+      tls:
+        certificates:
+          - certFile: /etc/traefik/certs/tls.crt
+            keyFile: /etc/traefik/certs/tls.key
 
   # 3. Write Traefik Systemd Container Service
   - path: /etc/systemd/system/traefik.service
@@ -226,7 +245,7 @@ runcmd:
     export DEBIAN_FRONTEND=noninteractive
     while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 2; done
     for i in $(seq 1 5); do
-      if apt-get update && apt-get install -y -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" docker.io systemd-resolved gnupg apt-transport-https wireguard-tools curl; then
+      if apt-get update && apt-get install -y -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" docker.io systemd-resolved gnupg apt-transport-https wireguard-tools curl openssl; then
         break
       fi
       sleep 3
@@ -280,6 +299,16 @@ runcmd:
   - echo "net.ipv4.tcp_keepalive_probes=3" >> /etc/sysctl.conf
   - echo "net.ipv4.tcp_retries2=5" >> /etc/sysctl.conf
 
+  # 5b. Bootstrap a self-signed cert so Traefik has something to serve on first boot;
+  #     the real wildcard cert is pushed moments later by the Terraform cert_sync provisioner.
+  - mkdir -p /etc/traefik/certs
+  - |
+    if [ ! -f /etc/traefik/certs/tls.crt ]; then
+      openssl req -x509 -nodes -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+        -keyout /etc/traefik/certs/tls.key -out /etc/traefik/certs/tls.crt \
+        -days 7 -subj "/CN=bootstrap.${SECRET_DOMAIN}"
+    fi
+
   # 6. Enable and start NetBird, NetBird Relay, Traefik, Node Exporter & CrowdSec Container
   - mkdir -p /var/lib/crowdsec/data
   - systemctl daemon-reload
@@ -310,6 +339,9 @@ runcmd:
     fi
 
   # 5. Wait for CrowdSec container to populate base /etc/crowdsec/config.yaml and write custom whitelist/acquisition
+  #    (bootstrap-only: no home IP yet, that's pushed in place by the Terraform
+  #    home_ip_whitelist_sync provisioner right after this instance comes up, and again
+  #    any time it changes, without ever replacing the instance)
   - |
     until docker exec crowdsec cscli config show >/dev/null 2>&1; do sleep 2; done
 
@@ -320,9 +352,8 @@ runcmd:
     description: "Whitelist trusted IPs and internal networks"
     filter: "1 == 1"
     whitelist:
-      reason: "Whitelisted home IP and internal overlay networks"
+      reason: "Whitelisted internal overlay networks"
       ip:
-        - "${HOME_IP}"
         - "127.0.0.1"
         - "::1"
       cidr:

--- a/cluster/apps/networking/ingress-vps/us/vps-cloud-init.yaml
+++ b/cluster/apps/networking/ingress-vps/us/vps-cloud-init.yaml
@@ -36,8 +36,10 @@ write_files:
       accessLog: {}
 
   # 2. Write Traefik Edge Ingress Proxy Dynamic Configuration (TLS terminated at the
-  #    edge, forwarded to the cluster's own websecure entrypoint over the wg0 tunnel;
-  #    wg0 already encrypts that leg, and terminating here lets Traefik pool/reuse the
+  #    edge, forwarded to the cluster's own websecure entrypoint over wt0 (NetBird's
+  #    tunnel, terminating on routing-peer pods inside the cluster - not wg0, which is
+  #    scoped to NB_ADDR/32 only, for bootstrapping enrollment, and can't reach it).
+  #    wt0 already encrypts that leg, and terminating here lets Traefik pool/reuse the
   #    backend connection instead of paying a full TLS handshake over the tunnel per
   #    client request, and gives CrowdSec real HTTP visibility instead of opaque TCP.
   - path: /etc/traefik/dynamic.yaml

--- a/cluster/apps/networking/netbird/control-plane/route.yaml
+++ b/cluster/apps/networking/netbird/control-plane/route.yaml
@@ -5,6 +5,11 @@ metadata:
   name: netbird-control-plane
   namespace: networking
   annotations:
+    # gRPC (management sync, signal exchange) needs streaming/trailers that Cloudflare's
+    # proxy only passes through correctly with its account-level gRPC support enabled;
+    # keep this on the VPS/raw-TCP path rather than the Cloudflare-Tunnel-primary default
+    # (see cluster/apps/networking/traefik/external/gateway.yaml) until that's confirmed.
+    external-dns.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
     gatus.io/enabled: "true"
     gatus.io/endpoint: |
       group: networking

--- a/cluster/apps/networking/traefik/external/gateway.yaml
+++ b/cluster/apps/networking/traefik/external/gateway.yaml
@@ -7,7 +7,11 @@ metadata:
   labels:
     gateway.home-operations.io/type: external
   annotations:
-    external-dns.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
+    # Default target for every attached route: Cloudflare Tunnel primary, VPS fallback
+    # (cluster/apps/networking/ingress-vps/failover-fast). Apps that need raw TCP or large
+    # sustained transfers (Plex, Immich, restic) override this back to ingress.${SECRET_DOMAIN}
+    # (VPS primary, Cloudflare Tunnel fallback) with their own route-level annotation.
+    external-dns.kubernetes.io/target: "fast.${SECRET_DOMAIN}"
     # Probe attached routes via public DNS (egress -> 1.1.1.1) so Gatus tests the
     # real external path. Inherited by all routes; per-route config wins on conflicts.
     gatus.io/endpoint: |


### PR DESCRIPTION
## Why

Gatus latency data showed the VPS ingress path averaging ~726ms vs. Cloudflare Tunnel's ~17ms for the same origin, root-caused to SNI passthrough forcing a fresh, non-multiplexed TLS handshake across the wg0 hop for every single request. Separately, a residential IP change or cert renewal was forcing a full VPS instance replace via `replace_triggered_by`.

## What changed

**TLS termination at the VPS** (`ingress-vps/us`, `ingress-vps/eu`, their `vps-cloud-init.yaml`)
- Traefik on both VPS regions now terminates TLS and forwards HTTP to the cluster's `websecure` entrypoint over wg0 (already encrypted at the WireGuard layer) with pooled/reused backend connections, instead of raw SNI passthrough.
- Gives CrowdSec real HTTP visibility (method/path) instead of opaque TCP.
- Bootstraps a short-lived self-signed cert at boot so Traefik has something to serve before the real cert lands.

**Cert + home-IP decoupled from instance replace**
- New `null_resource.cert_sync` / `null_resource.home_ip_whitelist_sync` per region: SSH-push the current cert-manager wildcard cert (read via `data.kubernetes_secret_v1`) and the current home egress IP, each keyed on its own content hash. Neither touches `user_data` anymore, so a cert renewal or a residential IP change no longer replaces the VPS.
- New dedicated `tls_private_key.tf_admin` automation keypair for this, separate from the human SSH key.

**Cloudflare Tunnel as the default ingress path**
- `traefik/external/gateway.yaml`'s default `external-dns.kubernetes.io/target` flips from `ingress.${domain}` to a new `fast.${domain}` (Cloudflare Tunnel primary, VPS fallback, own `failover-fast` worker/Terraform stack).
- Plex, immich-server (`photos.${domain}`, uploads/API), restic, and netbird keep the VPS-primary `ingress.${domain}` via a route-level override — large sustained transfers / gRPC streaming that don't suit Cloudflare's proxy limits. immich-proxy (`photo-share.${domain}`) is sharing-only, no uploads, so it stays on the Cloudflare-primary default like everything else.
- Both failover workers now probe **both** VPS regions every run (previously short-circuited) so they can prefer the pre-existing `proxy.${domain}` round-robin record when both are healthy, and fall back to a single region's own `vps-us`/`vps-eu` record when only one is.

**Bug fixes along the way**
- `vps-us`/`vps-eu` were being duplicated as `proxy-us`/`proxy-eu` in an earlier revision of this branch — removed, no functional difference from what already existed.
- Gatus config, the `vps-direct-health` catchall route, and `.taskfiles/test.yml`'s tofu-lint dir list updated to match.

## Testing

- `task test:lint:all` passes clean (kubeconform, yamllint, markdownlint, prettier, `tofu validate` on all four Terraform stacks).
- `tofu validate`/`tofu fmt` run individually against `us`, `eu`, `failover`, `failover-fast`.
- Could not `tofu plan`/`apply` against live OVH/Hetzner/Cloudflare accounts from this environment — no cloud credentials here.

## Before merging (real infra changes on apply — `tofu-infra-git` is pinned to `main`)

- **SSH default users are assumed, not verified**: `debian` for the OVH image, `root` for the Hetzner image. If either's wrong, `cert_sync`/`home_ip_whitelist_sync` will fail loudly (not silently) on the next 5-minute reconcile after merge — worth a quick manual check first.
- Merging replaces both VPS instances (cloud-init user_data changed) — expect a few minutes of VPS-path downtime for plex/immich/restic/netbird during cutover; the round-robin/failover logic should keep things degraded-but-up if only one region is mid-replace at a time, but both regions replacing close together is a real risk worth watching.
- Cloudflare's account-level gRPC toggle is already enabled per Brandon; netbird stays VPS-primary regardless for now, revisit moving it later.

