### PR TITLE
fix(ingress-vps): URGENT - Traefik v3 HostRegexp syntax + dead route-level target overrides

### DIFF
--- a/cluster/apps/backups/restic-rest-server/app/helm-release.yaml
+++ b/cluster/apps/backups/restic-rest-server/app/helm-release.yaml
@@ -111,16 +111,15 @@ spec:
       main:
         enabled: true
         annotations:
-          # Large backup uploads: keep on the VPS/raw-TCP path rather than the
-          # Cloudflare-Tunnel-primary default (see cluster/apps/networking/traefik/external/gateway.yaml).
-          # Also avoids Cloudflare's free-tier upload size/timeout limits on large snapshots.
-          external-dns.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
           gatus.io/enabled: "true"
           gatus.io/endpoint: |
             conditions:
               - "[STATUS] == 401"
         parentRefs:
-          - name: external-gateway
+          # Large backup uploads: VPS-primary gateway, not the Cloudflare-Tunnel-primary default
+          # (see cluster/apps/networking/traefik/external/gateway.yaml) - also avoids Cloudflare's
+          # free-tier upload size/timeout limits on large snapshots.
+          - name: external-gateway-vps
             namespace: networking
         hostnames:
           - "backups.${SECRET_DOMAIN}"

--- a/cluster/apps/household/immich/app/server-helm-release.yaml
+++ b/cluster/apps/household/immich/app/server-helm-release.yaml
@@ -86,12 +86,11 @@ spec:
       main:
         enabled: true
         annotations:
-          # Large media uploads/downloads: keep on the VPS/raw-TCP path rather than the
-          # Cloudflare-Tunnel-primary default (see cluster/apps/networking/traefik/external/gateway.yaml).
-          external-dns.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
           gatus.io/enabled: "true"
         parentRefs:
-          - name: external-gateway
+          # Large media uploads/downloads: VPS-primary gateway, not the Cloudflare-Tunnel-primary
+          # default (see cluster/apps/networking/traefik/external/gateway.yaml).
+          - name: external-gateway-vps
             namespace: networking
         hostnames:
           - "photos.${SECRET_DOMAIN}"

--- a/cluster/apps/media/plex/app/helm-release.yaml
+++ b/cluster/apps/media/plex/app/helm-release.yaml
@@ -92,15 +92,14 @@ spec:
       main:
         enabled: true
         annotations:
-          # Large sustained media streams: keep on the VPS/raw-TCP path rather than the
-          # Cloudflare-Tunnel-primary default (see cluster/apps/networking/traefik/external/gateway.yaml).
-          external-dns.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
           gatus.io/enabled: "true"
           gatus.io/endpoint: |
             conditions:
               - "[STATUS] == 401"
         parentRefs:
-          - name: external-gateway
+          # Large sustained media streams: VPS-primary gateway, not the Cloudflare-Tunnel-primary
+          # default (see cluster/apps/networking/traefik/external/gateway.yaml).
+          - name: external-gateway-vps
             namespace: networking
         hostnames:
           - "plex.${SECRET_DOMAIN}"

--- a/cluster/apps/networking/ingress-vps/eu/vps-cloud-init.yaml
+++ b/cluster/apps/networking/ingress-vps/eu/vps-cloud-init.yaml
@@ -49,12 +49,12 @@ write_files:
           web-catchall:
             entryPoints:
               - web
-            rule: "HostRegexp(`{host:.+}`)"
+            rule: "HostRegexp(`^.+$`)"
             service: k8s-http
           websecure-catchall:
             entryPoints:
               - websecure
-            rule: "HostRegexp(`{host:.+}`)"
+            rule: "HostRegexp(`^.+$`)"
             service: k8s-https
             tls: {}
         services:

--- a/cluster/apps/networking/ingress-vps/us/vps-cloud-init.yaml
+++ b/cluster/apps/networking/ingress-vps/us/vps-cloud-init.yaml
@@ -50,12 +50,12 @@ write_files:
           web-catchall:
             entryPoints:
               - web
-            rule: "HostRegexp(`{host:.+}`)"
+            rule: "HostRegexp(`^.+$`)"
             service: k8s-http
           websecure-catchall:
             entryPoints:
               - websecure
-            rule: "HostRegexp(`{host:.+}`)"
+            rule: "HostRegexp(`^.+$`)"
             service: k8s-https
             tls: {}
         services:

--- a/cluster/apps/networking/netbird/control-plane/route.yaml
+++ b/cluster/apps/networking/netbird/control-plane/route.yaml
@@ -5,18 +5,17 @@ metadata:
   name: netbird-control-plane
   namespace: networking
   annotations:
-    # gRPC (management sync, signal exchange) needs streaming/trailers that Cloudflare's
-    # proxy only passes through correctly with its account-level gRPC support enabled;
-    # keep this on the VPS/raw-TCP path rather than the Cloudflare-Tunnel-primary default
-    # (see cluster/apps/networking/traefik/external/gateway.yaml) until that's confirmed.
-    external-dns.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
     gatus.io/enabled: "true"
     gatus.io/endpoint: |
       group: networking
       path: /
 spec:
   parentRefs:
-    - name: external-gateway
+    # gRPC (management sync, signal exchange) needs streaming/trailers that Cloudflare's
+    # proxy only passes through correctly with its account-level gRPC support enabled;
+    # keep this on the VPS-primary gateway rather than the Cloudflare-Tunnel-primary default
+    # (see cluster/apps/networking/traefik/external/gateway.yaml) until that's confirmed.
+    - name: external-gateway-vps
       namespace: networking
   hostnames:
     - "nb.${SECRET_DOMAIN}"

--- a/cluster/apps/networking/traefik/external/gateway-vps.yaml
+++ b/cluster/apps/networking/traefik/external/gateway-vps.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: external-gateway-vps
+  namespace: networking
+  labels:
+    gateway.home-operations.io/type: external
+  annotations:
+    # Same Traefik instance/IP as external-gateway (traefik-external GatewayClass, one
+    # controller serves every attached Gateway) - this one exists only so external-dns
+    # (which reads the target annotation from the Gateway, never from a Route - see
+    # https://github.com/kubernetes-sigs/external-dns/issues/4779) can give a different
+    # set of routes a different target: VPS primary, Cloudflare Tunnel fallback, for
+    # apps that need raw TCP or large sustained transfers (Plex, Immich uploads, restic,
+    # netbird). Routes opt in via parentRefs, not an annotation on the route itself.
+    external-dns.kubernetes.io/target: "ingress.${SECRET_DOMAIN}"
+    gatus.io/endpoint: |
+      group: external
+      client:
+        dns-resolver: "udp://1.1.1.1:53"
+spec:
+  gatewayClassName: traefik-external
+  addresses:
+    - type: IPAddress
+      value: "10.0.10.20"
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8000
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      protocol: HTTPS
+      port: 8443
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: "wildcard-${SECRET_DOMAIN/./-}-tls"
+          - name: mlm-domains-tls

--- a/cluster/apps/networking/traefik/external/gateway.yaml
+++ b/cluster/apps/networking/traefik/external/gateway.yaml
@@ -9,8 +9,10 @@ metadata:
   annotations:
     # Default target for every attached route: Cloudflare Tunnel primary, VPS fallback
     # (cluster/apps/networking/ingress-vps/failover-fast). Apps that need raw TCP or large
-    # sustained transfers (Plex, Immich, restic) override this back to ingress.${SECRET_DOMAIN}
-    # (VPS primary, Cloudflare Tunnel fallback) with their own route-level annotation.
+    # sustained transfers (Plex, Immich uploads, restic, netbird) attach to
+    # external-gateway-vps instead (same Traefik instance/IP, different target) - external-dns
+    # only reads the target annotation from the Gateway, never from a Route, so a per-route
+    # override here does nothing: https://github.com/kubernetes-sigs/external-dns/issues/4779
     external-dns.kubernetes.io/target: "fast.${SECRET_DOMAIN}"
     # Probe attached routes via public DNS (egress -> 1.1.1.1) so Gatus tests the
     # real external path. Inherited by all routes; per-route config wins on conflicts.

--- a/cluster/apps/networking/traefik/external/kustomization.yaml
+++ b/cluster/apps/networking/traefik/external/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - route.yaml
   - gatewayclass.yaml
   - gateway.yaml
+  - gateway-vps.yaml


### PR DESCRIPTION
## URGENT - fixes a live outage caused by PR #5055

After #5055 merged, the US VPS Terraform apply is stuck failing its health check (`404` instead of `418`), which blocks `eu`/`failover`/`failover-fast` from ever applying. As a direct result **`fast.${SECRET_DOMAIN}` does not exist in DNS**, so every app that defaults to it (everything except plex/immich-server/restic/netbird) is currently unreachable (NXDOMAIN). Verified via DoH against Cloudflare's authoritative nameservers (raw `dig` is intercepted on this network, so that had to be ruled out first).

### Root cause 1: Traefik v3 rule syntax

`HostRegexp(`{host:.+}`)` is Traefik **v2** syntax (named capture groups). Traefik v3 defaults to v3 rule syntax, where `HostRegexp` takes a plain Go regexp — `{host:.+}` isn't valid there, so the router silently fails to register and Traefik falls through to its built-in 404 for every HTTPS request. This syntax was carried over unchanged from the pre-existing `web-catchall` router in #5055, which never surfaced this because before that PR nothing exercised an HTTP router on `websecure` (it was TCP-only SNI passthrough). Fixed to `HostRegexp(`^.+$`)` in both regions.

### Root cause 2: route-level target annotations are silently ignored

Separately confirmed (via DoH again) that Plex, Immich uploads (`photos.${SECRET_DOMAIN}`), and restic were all live on `fast.${SECRET_DOMAIN}` despite their `external-dns.kubernetes.io/target` override annotations from #5055. external-dns's `gateway-httproute` source only reads the `target` annotation from the parent **Gateway**, never from a Route — [kubernetes-sigs/external-dns#4779](https://github.com/kubernetes-sigs/external-dns/issues/4779). Those annotations have been inert since they were added.

Fix: a second Gateway (`external-gateway-vps`, same Traefik instance/IP, `traefik-external` GatewayClass) carrying `target=ingress.${SECRET_DOMAIN}`. Plex, immich-server, restic, and netbird now attach via `parentRefs` to that Gateway instead.

## Also verified (not a bug)

Checked whether `fast.${SECRET_DOMAIN}` needs `proxied: true` per Cloudflare's Tunnel CNAME requirements — it already does, both in the Terraform default and in both failover workers' `isProxied` logic for the tunnel tier. Not the cause.

## Testing

- `task test:lint:all` / `test:lint:yaml` pass.
- Could not `tofu plan`/apply from this environment (no cloud credentials) — can't fully simulate the fix landing on the already-replaced, currently-broken US VPS. Next Terraform reconcile (5m interval) after merge should retry the health check against the corrected config; if the US instance needs another replace to pick it up, expect another few minutes of VPS-path downtime.

**This should merge as soon as reasonably reviewed** — every non-VPS-primary app is unreachable until the Terraform chain unblocks.
