### PR TITLE
refactor(ingress-vps): EU-first canary + decouple failover monitors from VPS chain

### DIFF
--- a/cluster/apps/networking/ingress-vps/app/tofu.yaml
+++ b/cluster/apps/networking/ingress-vps/app/tofu.yaml
@@ -64,9 +64,12 @@ metadata:
   name: ingress-vps-failover
   namespace: networking
 spec:
-  dependsOn:
-    - name: ingress-vps-us
-      namespace: networking
+  # Deliberately independent of ingress-vps-eu/-us: this creates its own DNS record and
+  # worker, doesn't need either VPS to have ever successfully applied, and its probes
+  # already treat an unresolvable vps-us/vps-eu hostname as unhealthy - falling through to
+  # the Cloudflare Tunnel tier. If it depended on the VPS stacks, a broken VPS apply (like
+  # the one that just happened) would block this from ever deploying too, leaving no
+  # automatic fallback during exactly the outage it exists to route around.
   interval: 5m
   retryInterval: 1m
   approvePlan: auto
@@ -94,9 +97,9 @@ metadata:
   name: ingress-vps-failover-fast
   namespace: networking
 spec:
-  dependsOn:
-    - name: ingress-vps-failover
-      namespace: networking
+  # Deliberately independent - see the comment on ingress-vps-failover above. This
+  # record is the default target for nearly every externally-exposed app, so it
+  # matters even more that it can't be blocked by a broken VPS apply.
   interval: 5m
   retryInterval: 1m
   approvePlan: auto

--- a/cluster/apps/networking/ingress-vps/app/tofu.yaml
+++ b/cluster/apps/networking/ingress-vps/app/tofu.yaml
@@ -2,39 +2,11 @@
 apiVersion: infra.contrib.fluxcd.io/v1alpha2
 kind: Terraform
 metadata:
-  name: ingress-vps-us
-  namespace: networking
-spec:
-  interval: 5m
-  retryInterval: 1m
-  approvePlan: auto
-  destroyResourcesOnDeletion: true
-  path: ./cluster/apps/networking/ingress-vps/us
-  serviceAccountName: tf-runner
-  sourceRef:
-    kind: GitRepository
-    name: tofu-infra-git
-    namespace: networking
-  vars:
-    - name: secret_domain
-      value: "${SECRET_DOMAIN}"
-  varsFrom:
-    - kind: Secret
-      name: cloudflare-ddns
-    - kind: Secret
-      name: ingress-tunnel-secrets
-  writeOutputsToSecret:
-    name: vps-us-output
----
-apiVersion: infra.contrib.fluxcd.io/v1alpha2
-kind: Terraform
-metadata:
   name: ingress-vps-eu
   namespace: networking
 spec:
-  dependsOn:
-    - name: ingress-vps-us
-      namespace: networking
+  # EU applies first: it's the less-used region, so a bad Terraform/cloud-init change
+  # hits it before it ever reaches US.
   interval: 5m
   retryInterval: 1m
   approvePlan: auto
@@ -59,11 +31,41 @@ spec:
 apiVersion: infra.contrib.fluxcd.io/v1alpha2
 kind: Terraform
 metadata:
-  name: ingress-vps-failover
+  name: ingress-vps-us
   namespace: networking
 spec:
   dependsOn:
     - name: ingress-vps-eu
+      namespace: networking
+  interval: 5m
+  retryInterval: 1m
+  approvePlan: auto
+  destroyResourcesOnDeletion: true
+  path: ./cluster/apps/networking/ingress-vps/us
+  serviceAccountName: tf-runner
+  sourceRef:
+    kind: GitRepository
+    name: tofu-infra-git
+    namespace: networking
+  vars:
+    - name: secret_domain
+      value: "${SECRET_DOMAIN}"
+  varsFrom:
+    - kind: Secret
+      name: cloudflare-ddns
+    - kind: Secret
+      name: ingress-tunnel-secrets
+  writeOutputsToSecret:
+    name: vps-us-output
+---
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: ingress-vps-failover
+  namespace: networking
+spec:
+  dependsOn:
+    - name: ingress-vps-us
       namespace: networking
   interval: 5m
   retryInterval: 1m


### PR DESCRIPTION
Two related resilience fixes to the Terraform dependency chain, prompted directly by today's outage recovery:

1. **EU applies before US.** EU is the less-used region — swap the chain so it applies first, so a bad Terraform/cloud-init change hits it before it can cascade to US.

2. **failover/failover-fast no longer depend on the VPS stacks at all.** During today's incident, `ingress-vps-us` was stuck failing for hours, which — because of the old `eu -> us -> failover -> failover-fast` chain — meant the Cloudflare failover monitors never got deployed either. `fast.${domain}` (the default target for nearly every externally-exposed app) never got created, and there was no automatic fallback during exactly the kind of outage those monitors exist to route around. Both failover stacks create their own DNS record and worker and don't need either VPS region to have ever successfully applied — their probes already treat an unresolvable `vps-us`/`vps-eu` hostname as unhealthy and fall through to the Cloudflare Tunnel tier correctly.

Chain is now: `eu -> us` (canary ordering, unrelated to the rest), and `failover`/`failover-fast` apply independently in parallel with both.

No functional change to any individual stack's own resources - Flux orchestration only.