### PR TITLE
fix(ingress-vps): backend TLS transport needs explicit SNI (live-verified)

### DIFF
--- a/cluster/apps/networking/ingress-vps/eu/vps-cloud-init.yaml
+++ b/cluster/apps/networking/ingress-vps/eu/vps-cloud-init.yaml
@@ -73,6 +73,11 @@ write_files:
             # wildcard cert; skip verification because the transport itself (WireGuard)
             # is what actually authenticates this leg, not the TLS handshake.
             insecureSkipVerify: true
+            # The backend URL above is a bare IP, so no SNI would otherwise be sent;
+            # the cluster's Gateway has multiple certificateRefs and needs a matching
+            # SNI to pick one, or it hard-rejects the handshake with "unrecognized name"
+            # (confirmed live: this is what was causing every request to 502).
+            serverName: "${SECRET_DOMAIN}"
 
       tls:
         certificates:

--- a/cluster/apps/networking/ingress-vps/us/vps-cloud-init.yaml
+++ b/cluster/apps/networking/ingress-vps/us/vps-cloud-init.yaml
@@ -74,6 +74,11 @@ write_files:
             # wildcard cert; skip verification because the transport itself (WireGuard)
             # is what actually authenticates this leg, not the TLS handshake.
             insecureSkipVerify: true
+            # The backend URL above is a bare IP, so no SNI would otherwise be sent;
+            # the cluster's Gateway has multiple certificateRefs and needs a matching
+            # SNI to pick one, or it hard-rejects the handshake with "unrecognized name"
+            # (confirmed live: this is what was causing every request to 502).
+            serverName: "${SECRET_DOMAIN}"
 
       tls:
         certificates:


### PR DESCRIPTION
Third fix in the VPS TLS termination chain (#5055, #5056). Live-verified via SSH onto the already-replaced US VPS (key extracted from Terraform state with explicit approval) — root cause and fix confirmed working end-to-end before pushing, including a real named-app route (netbird dashboard), not just the health responder.

Root cause: the k8s-https backend URL is a bare IP (10.0.10.20), so no SNI was sent on the backend TLS handshake. The cluster's external-gateway has two certificateRefs (wildcard + mlm-domains-tls) and needs a matching SNI to pick one, or it hard-rejects with a TLS 'unrecognized name' alert — surfacing as 502 Bad Gateway on every single request.

Fix: explicit `serverName` on the serversTransport. HTTP-level routing is unaffected (Host header is preserved separately and is what Gateway API HTTPRoutes actually match on) — confirmed by hitting nb.${domain} through the VPS and getting the real NetBird dashboard back, not a generic response.

Note: merging this will trigger another instance replace for the US VPS (cloud-init content changed again since my live SSH hotfix isn't reflected in Terraform state) — expect a few more minutes of VPS-path downtime, but the new instance should boot straight into a working state this time.