### PR TITLE
fix(ingress-vps): cscli has no reload subcommand in v1.8, blocking home_ip_whitelist_sync

### DIFF
--- a/cluster/apps/networking/ingress-vps/eu/main.tf
+++ b/cluster/apps/networking/ingress-vps/eu/main.tf
@@ -397,7 +397,7 @@ resource "null_resource" "home_ip_whitelist_sync" {
     inline = [
       "install -o root -g root -m 0644 /tmp/00-whitelist.yaml /etc/crowdsec/parsers/s02-enrich/00-whitelist.yaml",
       "rm -f /tmp/00-whitelist.yaml",
-      "docker exec crowdsec cscli reload",
+      "docker exec crowdsec cscli reload || true",
     ]
   }
 

--- a/cluster/apps/networking/ingress-vps/eu/main.tf
+++ b/cluster/apps/networking/ingress-vps/eu/main.tf
@@ -397,7 +397,7 @@ resource "null_resource" "home_ip_whitelist_sync" {
     inline = [
       "install -o root -g root -m 0644 /tmp/00-whitelist.yaml /etc/crowdsec/parsers/s02-enrich/00-whitelist.yaml",
       "rm -f /tmp/00-whitelist.yaml",
-      "docker exec crowdsec cscli reload || true",
+      "docker exec crowdsec kill -SIGHUP 1",
     ]
   }
 

--- a/cluster/apps/networking/ingress-vps/eu/vps-cloud-init.yaml
+++ b/cluster/apps/networking/ingress-vps/eu/vps-cloud-init.yaml
@@ -382,7 +382,7 @@ runcmd:
       type: syslog
     EOF
 
-    docker exec crowdsec cscli reload || true
+    docker exec crowdsec kill -SIGHUP 1
 
   # 6. Install NFTables Firewall Bouncer on host & connect to containerized LAPI
   - |

--- a/cluster/apps/networking/ingress-vps/us/main.tf
+++ b/cluster/apps/networking/ingress-vps/us/main.tf
@@ -373,7 +373,7 @@ resource "null_resource" "home_ip_whitelist_sync" {
     inline = [
       "sudo install -o root -g root -m 0644 /tmp/00-whitelist.yaml /etc/crowdsec/parsers/s02-enrich/00-whitelist.yaml",
       "rm -f /tmp/00-whitelist.yaml",
-      "sudo docker exec crowdsec cscli reload",
+      "sudo docker exec crowdsec cscli reload || true",
     ]
   }
 

--- a/cluster/apps/networking/ingress-vps/us/main.tf
+++ b/cluster/apps/networking/ingress-vps/us/main.tf
@@ -373,7 +373,7 @@ resource "null_resource" "home_ip_whitelist_sync" {
     inline = [
       "sudo install -o root -g root -m 0644 /tmp/00-whitelist.yaml /etc/crowdsec/parsers/s02-enrich/00-whitelist.yaml",
       "rm -f /tmp/00-whitelist.yaml",
-      "sudo docker exec crowdsec cscli reload || true",
+      "sudo docker exec crowdsec kill -SIGHUP 1",
     ]
   }
 

--- a/cluster/apps/networking/ingress-vps/us/vps-cloud-init.yaml
+++ b/cluster/apps/networking/ingress-vps/us/vps-cloud-init.yaml
@@ -383,7 +383,7 @@ runcmd:
       type: syslog
     EOF
 
-    docker exec crowdsec cscli reload || true
+    docker exec crowdsec kill -SIGHUP 1
 
   # 6. Install NFTables Firewall Bouncer on host & connect to containerized LAPI
   - |


### PR DESCRIPTION
Fourth fix in the chain (#5055, #5056, #5058). Confirmed live via SSH on the stuck US VPS: `cscli reload` fails with 'unknown command "reload"' in CrowdSec v1.8 - it doesn't exist.

Initially fixed this by wrapping it in `|| true` to match the pre-existing bootstrap script, which does the exact same broken call - but that's just silencing a command that never did anything; CrowdSec was never actually picking up the whitelist/acquisition changes, config writes were succeeding but the reload never was, going back to whenever this VPS setup was first built.

Confirmed live the real mechanism instead: `docker exec crowdsec kill -SIGHUP 1` - sent it over SSH, watched crowdsec's own logs do a full clean reinit (LAPI, schedulers, grok library, the works). Fixed in both the new `home_ip_whitelist_sync` null_resource and the original cloud-init bootstrap step it was copied from, in both regions.