### PR TITLE
fix(networking): default apps to cloudflare-proxied, or Cloudflare Tunnel routes are unreachable

### DIFF
--- a/cluster/apps/backups/restic-rest-server/app/helm-release.yaml
+++ b/cluster/apps/backups/restic-rest-server/app/helm-release.yaml
@@ -111,6 +111,9 @@ spec:
       main:
         enabled: true
         annotations:
+          # VPS-primary: must NOT be proxied, or Cloudflare's edge intercepts this instead
+          # of the VPS (see external-dns's --cloudflare-proxied default).
+          external-dns.kubernetes.io/cloudflare-proxied: "false"
           gatus.io/enabled: "true"
           gatus.io/endpoint: |
             conditions:

--- a/cluster/apps/household/immich/app/server-helm-release.yaml
+++ b/cluster/apps/household/immich/app/server-helm-release.yaml
@@ -86,6 +86,9 @@ spec:
       main:
         enabled: true
         annotations:
+          # VPS-primary: must NOT be proxied, or Cloudflare's edge intercepts this instead
+          # of the VPS (see external-dns's --cloudflare-proxied default).
+          external-dns.kubernetes.io/cloudflare-proxied: "false"
           gatus.io/enabled: "true"
         parentRefs:
           # Large media uploads/downloads: VPS-primary gateway, not the Cloudflare-Tunnel-primary

--- a/cluster/apps/media/plex/app/helm-release.yaml
+++ b/cluster/apps/media/plex/app/helm-release.yaml
@@ -92,6 +92,9 @@ spec:
       main:
         enabled: true
         annotations:
+          # VPS-primary: must NOT be proxied, or Cloudflare's edge intercepts this instead
+          # of the VPS (see external-dns's --cloudflare-proxied default).
+          external-dns.kubernetes.io/cloudflare-proxied: "false"
           gatus.io/enabled: "true"
           gatus.io/endpoint: |
             conditions:

--- a/cluster/apps/networking/netbird/control-plane/route.yaml
+++ b/cluster/apps/networking/netbird/control-plane/route.yaml
@@ -5,6 +5,9 @@ metadata:
   name: netbird-control-plane
   namespace: networking
   annotations:
+    # VPS-primary: must NOT be proxied, or Cloudflare's edge intercepts this instead of
+    # the VPS (see external-dns's --cloudflare-proxied default).
+    external-dns.kubernetes.io/cloudflare-proxied: "false"
     gatus.io/enabled: "true"
     gatus.io/endpoint: |
       group: networking

--- a/cluster/apps/system/external-dns/app/helm-release.yaml
+++ b/cluster/apps/system/external-dns/app/helm-release.yaml
@@ -74,3 +74,13 @@ spec:
       - --gateway-label-filter=gateway.home-operations.io/type=external
       - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
       - --crd-source-kind=DNSEndpoint
+      # Default every record this manages to proxied. An unproxied CNAME chain that
+      # bottoms out at a Cloudflare Tunnel (fast.${SECRET_DOMAIN} -> <tunnelid>.cfargotunnel.com)
+      # only resolves to Cloudflare's real anycast IPs for the hostname that is *itself*
+      # proxied - an unproxied intermediate hop just returns the literal configured
+      # target, which for a tunnel is a deliberately unroutable address (confirmed live:
+      # every app CNAMEing through fast.${SECRET_DOMAIN} was unreachable by real clients
+      # until this). The handful of apps that need to stay on the VPS path (unproxied,
+      # since Cloudflare must not intercept them) override back with
+      # external-dns.kubernetes.io/cloudflare-proxied: "false" on their own route.
+      - --cloudflare-proxied


### PR DESCRIPTION
Root cause of the outage you're still seeing (Gatus red across the board, real requests failing) even after #5055/#5056/#5058/#5059 all merged and every Terraform stack went Ready.

Every app hostname (`meals.${domain}`, `photos.${domain}`, etc.) CNAMEs to `fast.${domain}`. `fast.${domain}` itself is proxied and resolves correctly to Cloudflare's real anycast IPs - I verified that directly. But **the individual app records are unproxied** (external-dns's default), and an unproxied CNAME chain through a Cloudflare Tunnel doesn't get flattened to a real anycast IP - it resolves to the tunnel's own AAAA/A record, which Cloudflare deliberately makes unroutable outside the proxy layer (exactly what their setup docs warn about: 'make sure the proxy toggle is on ... or the lookup will return the literal cfargotunnel.com hostname to clients, which they cannot reach').

Confirmed via Gatus's actual logged error for every failing app: `dial tcp [fd10:aec2:5dae::]:443: connect: network is unreachable` - that's the tunnel's deliberately-bogus IPv6 address, live-verified as Cloudflare's own real DNS answer for the unproxied chain (not network interception on my end, which I ruled out with DoH).

An earlier manual test of mine (curl with `--resolve` pinned to a real anycast IP) appeared to succeed and I reported it as confirmation - that was wrong methodology; forcing the IP bypasses the exact resolution path a real client or Gatus actually uses, so it masked the bug instead of catching it.

## Fix

`--cloudflare-proxied` as a default flag on external-dns (scoped to the external gateways only, via the existing `--gateway-label-filter`). Plex, immich-server, restic, and netbird - the apps that must stay on the VPS path - get an explicit `cloudflare-proxied: "false"` override on their own route, since Cloudflare intercepting those instead of passing through to the VPS is exactly what the VPS-primary carve-out exists to avoid.