### PR TITLE
fix(ingress-vps): cert/whitelist sync never re-runs on instance replace, EU ssh_keys duplicate

### DIFF
--- a/cluster/apps/networking/ingress-vps/eu/main.tf
+++ b/cluster/apps/networking/ingress-vps/eu/main.tf
@@ -139,7 +139,7 @@ resource "hcloud_server" "eu_vps" {
   image       = "debian-${split(".", local.debian_version)[0]}"
   server_type = "cx23"
   location    = "nbg1" # Nuremberg, Germany (Includes 20TB traffic limit)
-  ssh_keys    = concat(data.hcloud_ssh_keys.all_keys.ssh_keys[*].id, [hcloud_ssh_key.tf_admin.id])
+  ssh_keys    = distinct(concat(data.hcloud_ssh_keys.all_keys.ssh_keys[*].id, [hcloud_ssh_key.tf_admin.id]))
 
   public_net {
     ipv4_enabled = true
@@ -324,6 +324,10 @@ resource "null_resource" "cert_sync" {
       data.kubernetes_secret_v1.wildcard_cert.data["tls.crt"],
       data.kubernetes_secret_v1.wildcard_cert.data["tls.key"],
     ]))
+    # Also re-run whenever the instance itself gets replaced (e.g. a debian_version bump)
+    # even if the cert content hasn't changed - otherwise the new box is stuck on its
+    # bootstrap self-signed cert forever, since cert_hash alone never changes on its own.
+    instance_id = hcloud_server.eu_vps.id
   }
 
   connection {
@@ -363,6 +367,9 @@ resource "null_resource" "cert_sync" {
 resource "null_resource" "home_ip_whitelist_sync" {
   triggers = {
     home_ip = local.home_ip
+    # Also re-run whenever the instance itself gets replaced - see the matching note on
+    # cert_sync's instance_id trigger above.
+    instance_id = hcloud_server.eu_vps.id
   }
 
   connection {

--- a/cluster/apps/networking/ingress-vps/us/main.tf
+++ b/cluster/apps/networking/ingress-vps/us/main.tf
@@ -300,6 +300,10 @@ resource "null_resource" "cert_sync" {
       data.kubernetes_secret_v1.wildcard_cert.data["tls.crt"],
       data.kubernetes_secret_v1.wildcard_cert.data["tls.key"],
     ]))
+    # Also re-run whenever the instance itself gets replaced (e.g. a debian_version bump)
+    # even if the cert content hasn't changed - otherwise the new box is stuck on its
+    # bootstrap self-signed cert forever, since cert_hash alone never changes on its own.
+    instance_id = ovh_cloud_project_instance.us_vps.id
   }
 
   connection {
@@ -339,6 +343,9 @@ resource "null_resource" "cert_sync" {
 resource "null_resource" "home_ip_whitelist_sync" {
   triggers = {
     home_ip = local.home_ip
+    # Also re-run whenever the instance itself gets replaced - see the matching note on
+    # cert_sync's instance_id trigger above.
+    instance_id = ovh_cloud_project_instance.us_vps.id
   }
 
   connection {


### PR DESCRIPTION
Explains why the worker was still failing US over to the tunnel even after everything else merged, and why EU has been failing every apply.

**cert_sync/home_ip_whitelist_sync never re-run on instance replace.** Both null_resources trigger only on their own content changing - never on the VPS instance itself. Every replace since #5055 left the new box stuck on its 7-day bootstrap self-signed cert forever. Confirmed live via SSH: current US VPS's cert was `CN=bootstrap.sysinfra.pro`, self-issued 31 minutes prior. That's exactly why the failover worker (which validates certs, unlike my earlier `-k` curl checks) correctly saw US as unhealthy - the box was up, just serving the wrong cert - and failed `ingress.${domain}` over to the tunnel. Fixed by adding the instance's own id to both null_resources' triggers.

**EU ssh_keys duplicate.** `ssh_keys = concat(all_keys, [tf_admin.id])` duplicates once `tf_admin` exists, since `all_keys` (all keys in the Hetzner project) already includes it. Hetzner rejects the duplicate outright: `SSH-Keys must be unique`. This has been failing every EU apply since the null_resource/tf_admin work landed. Wrapped in `distinct()`.

Hotfixed the currently-running US VPS directly via SSH with the real wildcard cert while this merges - verified with full cert validation (no `-k`), and `ingress.${domain}` should self-correct back to the VPS once the failover worker's next 1-minute cycle sees it healthy again.