### PR TITLE
feat(gatus): add ordinary-app DNS/proxy routing health check

### DIFF
--- a/cluster/apps/monitoring/gatus/app/resources/config.yaml
+++ b/cluster/apps/monitoring/gatus/app/resources/config.yaml
@@ -161,6 +161,23 @@ endpoints:
     ui:
       hide-hostname: true
       hide-url: true
+  - name: Ordinary App DNS/Proxy Routing (flux-receiver)
+    group: external
+    # Unlike the checks above, this hits a real per-app hostname on the default
+    # Cloudflare-primary path (same external-dns-managed CNAME as any other app, e.g.
+    # meals/plans/etc.) rather than one of the meta hostnames external-dns never touches.
+    # Catches the class of bug where fast.${SECRET_DOMAIN} itself is healthy but an
+    # individual app's own CNAME record isn't proxied, so it can't reach the tunnel at
+    # all - the fast-failover worker's own tunnel-health probe can't see that, since it
+    # only tests a hostname (external.${SECRET_DOMAIN}) that's always explicitly proxied.
+    url: "https://flux-receiver.${SECRET_DOMAIN}"
+    interval: 2m
+    conditions:
+      - "[STATUS] == 404"
+    alerts: *alerts
+    ui:
+      hide-hostname: true
+      hide-url: true
   - name: Cloudflare Tunnel Direct
     group: external
     url: "https://external.${SECRET_DOMAIN}"


### PR DESCRIPTION
New Gatus check hitting flux-receiver.${SECRET_DOMAIN} - a real per-app hostname on the default Cloudflare-primary path, external-dns-managed like any other app - as an early-warning signal for today's bug class.

Why this specific hostname: it's the one hostname that already gets exercised constantly (every git push fires the GitHub webhook at it) and is easy to assert a stable expected response for (404 on a bare GET), without adding load to a real user-facing app.

The existing infra-level checks (fast/external/ingress) can't catch this bug class because they hit meta-hostnames external-dns doesn't manage the proxied flag for - external.${SECRET_DOMAIN} is always explicitly proxied via its DNSEndpoint, regardless of external-dns's default. This is why the fast-failover worker never triggered during today's incident: its own tunnel-health probe was genuinely passing the whole time.