### PR TITLE
fix(n8n): correct n8n-webhook Gatus condition (expects 404, n8n returns 200)

### DIFF
--- a/cluster/apps/household/n8n/app/helm-release.yaml
+++ b/cluster/apps/household/n8n/app/helm-release.yaml
@@ -94,7 +94,7 @@ spec:
           gatus.io/enabled: "true"
           gatus.io/endpoint: |
             conditions:
-              - "[STATUS] == 404"
+              - "[STATUS] == 200"
         parentRefs:
           - name: external-gateway
             namespace: networking


### PR DESCRIPTION
Not related to the VPS/Cloudflare-primary work in #5055-#5062 - a real, separate, pre-existing bug found while chasing why this check stayed red after everything else went green.

Confirmed by exec'ing directly into the Gatus pod's own network namespace and hitting the route's actual matched paths: `GET /webhook` and `GET /webhook-test` both return real n8n content, `200 OK`. Gatus auto-generates its check URL from the HTTPRoute's own declared path (not the bare hostname), so it's always been hitting n8n itself, not testing an intentionally-unmatched path at the gateway. The `[STATUS] == 404` condition just never matched what n8n actually returns there.