### PR TITLE
fix(openclaw): raise migrate init container memory limit to 2Gi

### DIFF
--- a/cluster/apps/ai/openclaw/app/helm-release.yaml
+++ b/cluster/apps/ai/openclaw/app/helm-release.yaml
@@ -91,9 +91,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 256Mi
-              limits:
                 memory: 512Mi
+              limits:
+                memory: 2Gi
         containers:
           app:
             image:


### PR DESCRIPTION
The openclaw migrate init container was OOMKilled (exit 137) on startup — confirmed live via `kubectl` (pod `Init:CrashLoopBackOff`, previous container state `OOMKilled`).

Root cause: the migrate init container runs `doctor --fix --allow-exec` (model catalog, plugin/skill diagnostics, security audit across both agents) followed by `doctor --session-sqlite import --session-sqlite-all-agents`. This has grown to need more than the 512Mi limit set when the auto-migrate step was first added — it's not specific to the 2026.8.2 bump (the HelmRelease had already rolled back to 2026.8.1 per Flux history, and that revision OOMs too).

Fix: bump the migrate init container to request 512Mi / limit 2Gi (plenty of headroom vs. node capacity, well under the app container's own 512Mi/12Gi profile).

`mise x -- task test:all` passes.