### PR TITLE
fix(openclaw): raise migrate init container memory limit

### DIFF
--- a/cluster/apps/ai/openclaw/app/helm-release.yaml
+++ b/cluster/apps/ai/openclaw/app/helm-release.yaml
@@ -91,9 +91,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 256Mi
-              limits:
                 memory: 512Mi
+              limits:
+                memory: 2Gi
         containers:
           app:
             image:


### PR DESCRIPTION
The `migrate` init container added in a87beb3d2..47f79be3f (auto-migrate state for openclaw v2026.8.x) was OOMKilling at its 512Mi memory limit while running `doctor --fix` + `session-sqlite import`, leaving the openclaw pod in CrashLoopBackOff since the 2026.8.1 image bump.

Raises requests/limits from 256Mi/512Mi to 512Mi/2Gi (node has ample free memory). Data on the PVC is small (largest sqlite ~13MB) — the migration itself is just memory-hungrier than the original limit allowed.

No CPU limit added, per repo convention.