### PR TITLE
fix(renovate): add sourceUrl override for mauriceboe/trek

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,7 @@
     "github>mrwulf/home-cluster//.github/renovate/autoMerge.json5",
     "github>mrwulf/home-cluster//.github/renovate/customManagers.json5",
     "github>mrwulf/home-cluster//.github/renovate/groups.json5",
+    "github>mrwulf/home-cluster//.github/renovate/sourceUrls.json5",
   ],
   enabled: true,
   dependencyDashboardTitle: "Renovate Dashboard",

--- a/.github/renovate/sourceUrls.json5
+++ b/.github/renovate/sourceUrls.json5
@@ -12,5 +12,50 @@
       matchPackageNames: ["docker.io/ollama/ollama", "ollama/ollama"],
       sourceUrl: "https://github.com/ollama/ollama",
     },
+    {
+      description: "docker.io/chromadb/chroma ships no OCI source label, so Renovate can't auto-detect its changelog",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["docker.io/chromadb/chroma", "chromadb/chroma"],
+      sourceUrl: "https://github.com/chroma-core/chroma",
+    },
+    {
+      description: "ghcr.io/coder/code-server ships no OCI source label, so Renovate can't auto-detect its changelog",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/coder/code-server"],
+      sourceUrl: "https://github.com/coder/code-server",
+    },
+    {
+      description: "netbird management/signal images ship no OCI source label; both live in the main netbird monorepo, distinct from netbirdio/dashboard which already resolves",
+      matchDatasources: ["docker"],
+      matchPackageNames: [
+        "docker.io/netbirdio/management",
+        "docker.io/netbirdio/signal",
+      ],
+      sourceUrl: "https://github.com/netbirdio/netbird",
+    },
+    {
+      description: "ghcr.io/miguelndecarvalho/speedtest-exporter ships no OCI source label, so Renovate can't auto-detect its changelog",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/miguelndecarvalho/speedtest-exporter"],
+      sourceUrl: "https://github.com/MiguelNdeCarvalho/speedtest-exporter",
+    },
+    {
+      description: "docker.io/bellamy/scrob ships no OCI source label; the Docker Hub namespace (bellamy) differs from the GitHub org (ellite), same as ghcr.io/ellite/wallos",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["docker.io/bellamy/scrob", "bellamy/scrob"],
+      sourceUrl: "https://github.com/ellite/scrob",
+    },
+    {
+      description: "bruceforce/vaultwarden-backup ships no OCI source label, so Renovate can't auto-detect its changelog",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["bruceforce/vaultwarden-backup"],
+      sourceUrl: "https://github.com/Bruceforce/vaultwarden-backup",
+    },
+    {
+      description: "vikunja/api and vikunja/frontend ship no OCI source label; the project's GitHub org is go-vikunja, not vikunja",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["vikunja/api", "vikunja/frontend"],
+      sourceUrl: "https://github.com/go-vikunja/vikunja",
+    },
   ],
 }

--- a/.github/renovate/sourceUrls.json5
+++ b/.github/renovate/sourceUrls.json5
@@ -6,5 +6,11 @@
       matchPackageNames: ["mauriceboe/trek"],
       sourceUrl: "https://github.com/liketrek/TREK",
     },
+    {
+      description: "docker.io/ollama/ollama ships no OCI source label, so Renovate can't auto-detect its changelog",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["docker.io/ollama/ollama", "ollama/ollama"],
+      sourceUrl: "https://github.com/ollama/ollama",
+    },
   ],
 }

--- a/.github/renovate/sourceUrls.json5
+++ b/.github/renovate/sourceUrls.json5
@@ -1,0 +1,10 @@
+{
+  packageRules: [
+    {
+      description: "mauriceboe/trek ships no OCI source label, so Renovate can't auto-detect its changelog",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["mauriceboe/trek"],
+      sourceUrl: "https://github.com/liketrek/TREK",
+    },
+  ],
+}


### PR DESCRIPTION
Adds `sourceUrl` packageRule overrides for images/charts where Renovate can't auto-detect a changelog source, so their PRs stop shipping with no "Release Notes" section.

Split into a new `.github/renovate/sourceUrls.json5`, following the repo's existing per-topic file convention (`groups.json5`, `customManagers.json5`, `autoMerge.json5`, `disabledDatasources.json5`) rather than growing the root config further.

## Fixed (verified real upstream repo + matching tag/release before adding)

- `mauriceboe/trek` → `liketrek/TREK`
- `docker.io/ollama/ollama` → `ollama/ollama`
- `docker.io/chromadb/chroma` → `chroma-core/chroma`
- `ghcr.io/coder/code-server` → `coder/code-server`
- `docker.io/netbirdio/management` and `docker.io/netbirdio/signal` → `netbirdio/netbird` (the monorepo; distinct from `netbirdio/dashboard`, which already resolved)
- `ghcr.io/miguelndecarvalho/speedtest-exporter` → `MiguelNdeCarvalho/speedtest-exporter`
- `docker.io/bellamy/scrob` → `ellite/scrob` (Docker Hub namespace differs from the GitHub org, same pattern as `ghcr.io/ellite/wallos`)
- `bruceforce/vaultwarden-backup` → `Bruceforce/vaultwarden-backup`
- `vikunja/api` and `vikunja/frontend` → `go-vikunja/vikunja` (project's GitHub org, not `vikunja`)

## Audited and confirmed NOT fixable this way

- `goldilocks` (Helm): source already resolves correctly to `FairwindsOps/goldilocks`, it just has no GitHub Release tagged to match the chart version
- `lusotycoon/apache-exporter`: no confidently-identifiable upstream repo
- `dpage/pgadmin4`: canonical source isn't GitHub (git.postgresql.org)
- `docker.io/library/wordpress`: official image, already handled by Renovate's own docker-library heuristics
- `alpine/kubectl`: generic utility image, no single canonical project
- `ghcr.io/gimlet-io/capacitor`: real repo exists but its tag scheme (date-based) doesn't match the version pinned here
- `ghcr.io/pewdiepie-archdaemon/odysseus`: pinned to `tag: latest`, so Renovate never opens a version-bump PR for it
- `forgejo/forgejo`: not a changelog-source problem — the image isn't actually published to docker.io at all (Forgejo publishes to codeberg.org/forgejo/forgejo and code.forgejo.org instead)

Verified: `mise x -- task test:lint:all` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dQbQwGeL4AWzQtAg5s8Je