### PR TITLE
fix(tuppr): bump talos upgrade to v1.13.10, fix renovate tracking

### DIFF
--- a/.github/renovate/customManagers.json5
+++ b/.github/renovate/customManagers.json5
@@ -48,7 +48,7 @@
       ],
       managerFilePatterns: ["/(^|/)(cluster|talos)/.+\\.ya?ml$/"],
       matchStrings: [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n\\s*#?\\s*(?:ref|commit|version|tag):\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?",
+        "# renovate: depName=(?<depName>\\S+)(?: datasource=(?<datasource>\\S+))?(?: versioning=(?<versioning>\\S+))?\\s*\\n\\s*#?\\s*(?:ref|commit|version|tag):\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?",
       ],
       datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}git-refs{{/if}}",
     },

--- a/cluster/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/cluster/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: depName=ghcr.io/siderolabs/installer datasource=docker
-    version: v1.13.9
+    version: v1.13.10
   policy:
     rebootMode: powercycle
   healthChecks:


### PR DESCRIPTION
## What

PR #5088 bumped `talos/talenv.yaml` and the talos-backup cronjob to v1.13.10 but missed `cluster/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml`, leaving the tuppr `TalosUpgrade` resource pinned at v1.13.9.

## Root cause

The customManager regex in `.github/renovate/customManagers.json5` for `version:`/`tag:`/`ref:`/`commit:` fields required the comment as `# renovate: datasource=X depName=Y`, but `talosupgrade.yaml` (and `kubernetesupgrade.yaml`) use `# renovate: depName=X datasource=Y` — the order documented in this repo's `CLAUDE.md`. The mismatch meant Renovate never tracked this field at all, so it silently drifted (and PR #5081, the pending 1.14.0 bump, has the same gap).

## Fix

- Bump `talosupgrade.yaml` to `v1.13.10` to match the rest of main.
- Swap the regex's expected comment order to `depName=X datasource=Y` so this field (and `kubernetesupgrade.yaml`'s) is picked up by Renovate going forward.

Verified with `mise x -- task test:all` (lint:all hard gate passes; flux:build/check informational steps pass as expected in a non-bootstrapped local run).

## Talos v1.14.0 upgrade prep

Added `talos/UPGRADE_1.14.0.md` — a review of the [v1.14.0 release notes](https://github.com/siderolabs/talos/releases/tag/v1.14.0) against every relevant file under `talos/patches/`, so the actual version bump (PR #5081) has a checklist to work from. Documentation only, no config changes applied yet.

- **Worth doing at the same time as the bump**: fold `.machine.features.hostDNS` into the existing `ResolverConfig` document (its new home per the release notes); also found — independent of the user's original list — that `ghcr.io/siderolabs/installer` (this repo's Renovate anchor for the Talos version) stops being published starting 1.14.0, so both `talenv.yaml` and `talosupgrade.yaml` should switch their Renovate `depName`/`datasource` to the still-published `siderolabs/talos` / `github-releases` pair before 1.14.x patch tracking goes stale.
- **Recommended, no urgency** (all deprecated-but-supported today): sysctl/sysfs/kernel-module/udev-rules multi-document split, `SecurityProfileConfig` (`workloadIsolation: true`) with caveats around Rook-Ceph and in-tree iSCSI (none found in this repo), `FilesystemTrimConfig`, `KubePrismConfig`, and optionally `EtcFileConfig`/`CRICustomizationConfig` for the existing `nfs.yaml`/`containerd.yaml` file patches.
- **Not applicable to this repo**: the etcd monitoring-endpoint move (2379→2383) — this repo already scrapes etcd metrics on a dedicated custom port (2381) via `listen-metrics-urls`, which the release notes explicitly say is unaffected — plus `UnattendedInstallConfig`, Flannel, multipath, dedicated system volumes, XFS allocation-group geometry, and the TLS 1.3 minimum, each with reasoning in the doc.
- **Prep that's safe to do now, under 1.13.x**: switch the Renovate anchor (above); confirmed no in-tree iSCSI or custom TLS cipher-suite config exists today, clearing the way for the optional items later; sequence the version bump and the optional config migrations as separate changes so a regression is easy to attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXL3VtihCSXWH8DdYQvCa6
